### PR TITLE
feat: Static selection service selects a random endpoint from each stakeholder

### DIFF
--- a/pkg/internal/mock/config/mock_service.go
+++ b/pkg/internal/mock/config/mock_service.go
@@ -1,0 +1,34 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+// MockConfigService implements a mock config service
+type MockConfigService struct {
+	GetConsortiumFunc  func(string, string) (*models.ConsortiumFileData, error)
+	GetStakeholderFunc func(string, string) (*models.StakeholderFileData, error)
+}
+
+// GetConsortium get the consortium config file for a given domain from the given url
+func (m *MockConfigService) GetConsortium(url, domain string) (*models.ConsortiumFileData, error) {
+	if m.GetConsortiumFunc != nil {
+		return m.GetConsortiumFunc(url, domain)
+	}
+
+	return nil, nil
+}
+
+// GetStakeholder get the stakeholder config file for a given domain from the given url
+func (m *MockConfigService) GetStakeholder(url, domain string) (*models.StakeholderFileData, error) {
+	if m.GetConsortiumFunc != nil {
+		return m.GetStakeholderFunc(url, domain)
+	}
+
+	return nil, nil
+}

--- a/pkg/internal/mock/endpoint/mock_service.go
+++ b/pkg/internal/mock/endpoint/mock_service.go
@@ -3,19 +3,19 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package discovery
+package endpoint
 
 import (
 	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
 )
 
-// MockDiscoveryService implements a mock discovery service
-type MockDiscoveryService struct {
+// MockEndpointService implements a mock endpoint service
+type MockEndpointService struct {
 	GetEndpointsFunc func(domain string) ([]*models.Endpoint, error)
 }
 
-// GetEndpoints discover endpoints from a consortium
-func (m *MockDiscoveryService) GetEndpoints(domain string) ([]*models.Endpoint, error) {
+// GetEndpoints discover endpoints for a consortium domain
+func (m *MockEndpointService) GetEndpoints(domain string) ([]*models.Endpoint, error) {
 	if m.GetEndpointsFunc != nil {
 		return m.GetEndpointsFunc(domain)
 	}

--- a/pkg/internal/mock/models/mock_models.go
+++ b/pkg/internal/mock/models/mock_models.go
@@ -1,0 +1,59 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+// DummyJWSWrap wraps a config JSON in a dummy JWS
+func DummyJWSWrap(data string) string {
+	dataB64 := base64.RawURLEncoding.EncodeToString([]byte(data))
+	return `{"payload":"` + dataB64 + `","signatures":[{"header":{"kid":""}, "signature":""}]}`
+}
+
+// DummyConsortium creates a default consortium object
+func DummyConsortium(consortiumDomain string, stakeholders []models.StakeholderListElement) *models.Consortium {
+	cc := &models.Consortium{
+		Domain:   consortiumDomain,
+		Policy:   models.ConsortiumPolicy{Cache: models.CacheControl{MaxAge: 0}},
+		Members:  stakeholders,
+		Previous: "",
+	}
+
+	return cc
+}
+
+// DummyConsortiumJSON creates a dummy consortium JSON config
+func DummyConsortiumJSON(consortiumDomain string, stakeholders []models.StakeholderListElement) (string, error) {
+	out, err := json.Marshal(DummyConsortium(consortiumDomain, stakeholders))
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
+}
+
+// DummyStakeholderJSON creates a dummy stakeholder JSON config
+func DummyStakeholderJSON(stakeholderDomain string, endpoints []string) (string, error) {
+	sc := models.Stakeholder{
+		Domain:    stakeholderDomain,
+		DID:       "",
+		Policy:    models.StakeholderSettings{Cache: models.CacheControl{MaxAge: 0}},
+		Endpoints: endpoints,
+		Previous:  "",
+	}
+
+	out, err := json.Marshal(sc)
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
+}

--- a/pkg/internal/mock/selection/mock_service.go
+++ b/pkg/internal/mock/selection/mock_service.go
@@ -5,17 +5,19 @@ SPDX-License-Identifier: Apache-2.0
 
 package discovery
 
-import "github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/endpoint"
+import (
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
 
 // MockSelectionService implements a mock selection service
 type MockSelectionService struct {
-	SelectEndpointsFunc func(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error)
+	SelectEndpointsFunc func(domain string, endpoints []*models.Endpoint) ([]*models.Endpoint, error)
 }
 
 // SelectEndpoints select endpoints
-func (m *MockSelectionService) SelectEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+func (m *MockSelectionService) SelectEndpoints(domain string, endpoints []*models.Endpoint) ([]*models.Endpoint, error) { // nolint: lll
 	if m.SelectEndpointsFunc != nil {
-		return m.SelectEndpointsFunc(endpoints)
+		return m.SelectEndpointsFunc(domain, endpoints)
 	}
 
 	return nil, nil

--- a/pkg/vdri/trustbloc/config/httpconfig/service.go
+++ b/pkg/vdri/trustbloc/config/httpconfig/service.go
@@ -1,0 +1,103 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpconfig
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+// ConfigService fetches consortium and stakeholder configs over http
+type ConfigService struct {
+	httpClient *http.Client
+	tlsConfig  *tls.Config
+}
+
+// NewService create new ConfigService
+func NewService(opts ...Option) *ConfigService {
+	configService := &ConfigService{httpClient: &http.Client{}}
+
+	for _, opt := range opts {
+		opt(configService)
+	}
+
+	configService.httpClient.Transport = &http.Transport{TLSClientConfig: configService.tlsConfig}
+
+	return configService
+}
+
+const consortiumURLInfix = "/.well-known/did-trustbloc/"
+const consortiumURLSuffix = ".json"
+
+func configURL(urlDomain, consortiumDomain string) string {
+	prefix := ""
+	if !strings.HasPrefix(urlDomain, "http://") && !strings.HasPrefix(urlDomain, "https://") {
+		prefix = "https://"
+	}
+
+	return prefix + urlDomain + consortiumURLInfix + consortiumDomain + consortiumURLSuffix
+}
+
+// GetConsortium fetches and parses the consortium file at the given domain
+func (cs *ConfigService) GetConsortium(url, domain string) (*models.ConsortiumFileData, error) {
+	res, err := cs.httpClient.Get(configURL(url, domain))
+	if err != nil {
+		return nil, err
+	}
+
+	// nolint: errcheck
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != 200 {
+		// TODO retry
+		return nil, fmt.Errorf("consortium config request failed: error %d, `%s`", res.StatusCode, string(body))
+	}
+
+	return models.ParseConsortium(body)
+}
+
+// GetStakeholder fetches and parses a stakeholder file under the given url with the given domain
+func (cs *ConfigService) GetStakeholder(url, domain string) (*models.StakeholderFileData, error) {
+	res, err := cs.httpClient.Get(configURL(url, domain))
+	if err != nil {
+		return nil, err
+	}
+
+	// nolint: errcheck
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != 200 {
+		// TODO retry
+		return nil, fmt.Errorf("stakeholder config request failed: error %d, `%s`", res.StatusCode, string(body))
+	}
+
+	return models.ParseStakeholder(body)
+}
+
+// Option is a config service instance option
+type Option func(opts *ConfigService)
+
+// WithTLSConfig option is for definition of secured HTTP transport using a tls.Config instance
+func WithTLSConfig(tlsConfig *tls.Config) Option {
+	return func(opts *ConfigService) {
+		opts.tlsConfig = tlsConfig
+	}
+}

--- a/pkg/vdri/trustbloc/config/httpconfig/service_test.go
+++ b/pkg/vdri/trustbloc/config/httpconfig/service_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpconfig
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mockmodels "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/models"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+func TestDiscoveryService_getConsortiumData(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		consortiumData, err := mockmodels.DummyConsortiumJSON("foo.bar", []models.StakeholderListElement{
+			{
+				Domain: "bar.baz",
+			},
+			{
+				Domain: "baz.qux",
+			},
+		})
+		require.NoError(t, err)
+
+		consortiumFile := mockmodels.DummyJWSWrap(consortiumData)
+
+		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, consortiumFile)
+		}))
+		defer serv.Close()
+
+		cs := NewService()
+
+		conf, err := cs.GetConsortium(serv.URL, "foo.bar")
+		require.NoError(t, err)
+
+		require.Equal(t, "foo.bar", conf.Config.Domain)
+	})
+
+	t.Run("failure: can't reach server", func(t *testing.T) {
+		cs := NewService()
+
+		_, err := cs.GetConsortium("https://0.0.0.0:8080", "foo.bar")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "connection refused")
+	})
+
+	t.Run("failure: bad response", func(t *testing.T) {
+		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(500)
+		}))
+		defer serv.Close()
+
+		cs := NewService()
+
+		_, err := cs.GetConsortium(serv.URL, "foo.bar")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "consortium config request failed")
+	})
+
+	t.Run("failure: empty response", func(t *testing.T) {
+		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer serv.Close()
+
+		cs := NewService()
+
+		_, err := cs.GetConsortium(serv.URL, "foo.bar")
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), "consortium config data should be a JWS")
+	})
+}
+
+func TestDiscoveryService_getStakeholderData(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		stakeholderData, err := mockmodels.DummyStakeholderJSON("foo.bar", []string{
+			"endpoint.website/go/here/",
+			"endpoint.website/here/too/",
+		})
+		require.NoError(t, err)
+
+		stakeholderFile := mockmodels.DummyJWSWrap(stakeholderData)
+
+		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, stakeholderFile)
+		}))
+		defer serv.Close()
+
+		cs := NewService()
+
+		conf, err := cs.GetStakeholder(serv.URL, "foo.bar")
+		require.NoError(t, err)
+
+		require.Equal(t, "foo.bar", conf.Config.Domain)
+	})
+
+	t.Run("failure: can't reach server", func(t *testing.T) {
+		cs := NewService()
+
+		_, err := cs.GetStakeholder("https://0.0.0.0:8080", "foo.bar")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "connection refused")
+	})
+
+	t.Run("failure: bad response", func(t *testing.T) {
+		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(500)
+		}))
+		defer serv.Close()
+
+		cs := NewService()
+
+		_, err := cs.GetStakeholder(serv.URL, "foo.bar")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "stakeholder config request failed")
+	})
+
+	t.Run("failure: empty response", func(t *testing.T) {
+		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer serv.Close()
+
+		cs := NewService()
+
+		_, err := cs.GetStakeholder(serv.URL, "foo.bar")
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), "stakeholder config data should be a JWS")
+	})
+}
+
+func Test_configURL(t *testing.T) {
+	tests := [][2]string{ // first element is the test value, second is the correct value
+		{
+			configURL("http://foo.example.com", "foo.example.com"),
+			"http://foo.example.com/.well-known/did-trustbloc/foo.example.com.json",
+		},
+		{ // adds http:// to the front of a domain
+			configURL("foo.example.com", "foo.example.com"),
+			"https://foo.example.com/.well-known/did-trustbloc/foo.example.com.json",
+		},
+		{ // doesn't work with full URLs in the domain field
+			configURL("foo.example.com", "http://foo.example.com"),
+			"https://foo.example.com/.well-known/did-trustbloc/http://foo.example.com.json",
+		},
+		{
+			configURL("http://foo.example.com", "bar.baz.qux"),
+			"http://foo.example.com/.well-known/did-trustbloc/bar.baz.qux.json",
+		},
+		{
+			configURL("a", "b"),
+			"https://a/.well-known/did-trustbloc/b.json",
+		},
+		{ // doesn't recognize urls that aren't http:// or https://
+			configURL("ws:abcdefg", "hijklmn"),
+			"https://ws:abcdefg/.well-known/did-trustbloc/hijklmn.json",
+		},
+		{ // doesn't work well with malformed urls
+			configURL("http:/abcdefg", "hijklmn"),
+			"https://http:/abcdefg/.well-known/did-trustbloc/hijklmn.json",
+		},
+	}
+
+	for _, test := range tests {
+		require.Equal(t, test[1], test[0])
+	}
+}
+
+func TestOpts(t *testing.T) {
+	t.Run("test opts", func(t *testing.T) {
+		// test WithTLSConfig
+		var opts []Option
+		opts = append(opts, WithTLSConfig(&tls.Config{ServerName: "test"}))
+
+		cs := &ConfigService{}
+
+		// Apply options
+		for _, opt := range opts {
+			opt(cs)
+		}
+
+		require.Equal(t, "test", cs.tlsConfig.ServerName)
+	})
+}

--- a/pkg/vdri/trustbloc/discovery/staticdiscovery/service.go
+++ b/pkg/vdri/trustbloc/discovery/staticdiscovery/service.go
@@ -1,131 +1,84 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+
 SPDX-License-Identifier: Apache-2.0
 */
 
 package staticdiscovery
 
 import (
-	"crypto/tls"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"strings"
 
-	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/config"
-	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/endpoint"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
 )
 
-// DiscoveryService implements a static discovery service
+type config interface {
+	GetConsortium(url, domain string) (*models.ConsortiumFileData, error)
+	GetStakeholder(url, domain string) (*models.StakeholderFileData, error)
+}
+
+// DiscoveryService fetches endpoints for a consortium
 type DiscoveryService struct {
-	httpClient *http.Client
-	tlsConfig  *tls.Config
+	config config
 }
 
-// NewService return static discovery service
-func NewService(opts ...Option) *DiscoveryService {
-	d := &DiscoveryService{httpClient: &http.Client{}}
-
-	// Apply options
-	for _, opt := range opts {
-		opt(d)
+// NewService create new DiscoveryService
+func NewService(c config) *DiscoveryService {
+	endpointService := &DiscoveryService{
+		config: c,
 	}
 
-	d.httpClient.Transport = &http.Transport{TLSClientConfig: d.tlsConfig}
-
-	return d
+	return endpointService
 }
 
-// GetEndpoints discover endpoints from domain
-func (ds *DiscoveryService) GetEndpoints(domain string) ([]*endpoint.Endpoint, error) {
-	configData, err := ds.getConsortium(domain, domain)
+// GetEndpoints get a list of endpoints to use from a consortium domain
+func (ds *DiscoveryService) GetEndpoints(consortiumDomain string) ([]*models.Endpoint, error) {
+	consortiumData, err := ds.config.GetConsortium(consortiumDomain, consortiumDomain)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting consortium: %w", err)
 	}
 
-	var endpoints []*endpoint.Endpoint
+	consortium := consortiumData.Config
+	if consortium == nil {
+		return nil, fmt.Errorf("consortium config is nil")
+	}
 
-	for _, s := range configData.Config.Members {
-		stakeholderConfig, err := ds.getStakeholder(s.Domain, s.Domain)
+	stakeholders, err := ds.getStakeholderConfigs(consortium)
+	if err != nil {
+		return nil, fmt.Errorf("stakeholder config: %w", err)
+	}
+
+	return ds.getEndpointsFromStakeholders(stakeholders), nil
+}
+
+// getStakeholderConfigs gets the list of stakeholder configs
+func (ds *DiscoveryService) getStakeholderConfigs(consortium *models.Consortium) ([]models.StakeholderFileData, error) { // nolint: lll
+	var stakeholders []models.StakeholderFileData
+
+	for _, s := range consortium.Members {
+		stakeholderConfig, err := ds.config.GetStakeholder(s.Domain, s.Domain)
 		if err != nil {
 			return nil, err
 		}
 
+		stakeholders = append(stakeholders, *stakeholderConfig)
+	}
+
+	return stakeholders, nil
+}
+
+// getEndpointsFromStakeholders constructs the list of endpoints from the data in the list of stakeholders
+func (ds *DiscoveryService) getEndpointsFromStakeholders(stakeholders []models.StakeholderFileData) []*models.Endpoint {
+	var endpoints []*models.Endpoint
+
+	for _, stakeholderConfig := range stakeholders {
 		for _, ep := range stakeholderConfig.Config.Endpoints {
-			endpoints = append(endpoints, &endpoint.Endpoint{
+			endpoints = append(endpoints, &models.Endpoint{
 				URL:    ep,
-				Domain: s.Domain,
+				Domain: stakeholderConfig.Config.Domain,
 			})
 		}
 	}
 
-	return endpoints, nil
-}
-
-const consortiumURLInfix = "/.well-known/did-trustbloc/"
-const consortiumURLSuffix = ".json"
-
-func configURL(urlDomain, consortiumDomain string) string {
-	prefix := ""
-	if !strings.HasPrefix(urlDomain, "http://") && !strings.HasPrefix(urlDomain, "https://") {
-		prefix = "https://"
-	}
-
-	return prefix + urlDomain + consortiumURLInfix + consortiumDomain + consortiumURLSuffix
-}
-
-// getConsortiumFileData fetches and parses the consortium file at the given domain
-func (ds *DiscoveryService) getConsortium(url, domain string) (*config.ConsortiumFileData, error) {
-	res, err := ds.httpClient.Get(configURL(url, domain))
-	if err != nil {
-		return nil, err
-	}
-
-	// nolint: errcheck
-	defer res.Body.Close()
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.StatusCode != 200 {
-		// TODO retry
-		return nil, fmt.Errorf("consortium config request failed: error %d, `%s`", res.StatusCode, string(body))
-	}
-
-	return config.ParseConsortium(body)
-}
-
-// getStakeholder fetches and parses the stakeholder file at the given domain
-func (ds *DiscoveryService) getStakeholder(url, domain string) (*config.StakeholderFileData, error) {
-	res, err := ds.httpClient.Get(configURL(url, domain))
-	if err != nil {
-		return nil, err
-	}
-
-	// nolint: errcheck
-	defer res.Body.Close()
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.StatusCode != 200 {
-		// TODO retry
-		return nil, fmt.Errorf("stakeholder config request failed: error %d, `%s`", res.StatusCode, string(body))
-	}
-
-	return config.ParseStakeholder(body)
-}
-
-// Option is a discovery service instance option
-type Option func(opts *DiscoveryService)
-
-// WithTLSConfig option is for definition of secured HTTP transport using a tls.Config instance
-func WithTLSConfig(tlsConfig *tls.Config) Option {
-	return func(opts *DiscoveryService) {
-		opts.tlsConfig = tlsConfig
-	}
+	return endpoints
 }

--- a/pkg/vdri/trustbloc/discovery/staticdiscovery/service_test.go
+++ b/pkg/vdri/trustbloc/discovery/staticdiscovery/service_test.go
@@ -7,8 +7,6 @@ package staticdiscovery
 
 import (
 	"crypto/tls"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,32 +14,34 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/config"
+	mockmodels "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/models"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/config/httpconfig"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
 )
 
 func TestDiscoveryService_GetEndpoints(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		shData1, err := dummyStakeholderConfig("bar.baz", []string{
+		shData1, err := mockmodels.DummyStakeholderJSON("bar.baz", []string{
 			"https://bar.baz/webapi/123456", "https://bar.baz/webapi/654321"})
 		require.NoError(t, err)
 
-		shFile1 := dummyJWSWrap(shData1)
+		shFile1 := mockmodels.DummyJWSWrap(shData1)
 		stakeholderServ1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, shFile1)
 		}))
 		defer stakeholderServ1.Close()
 
-		shData2, err := dummyStakeholderConfig("baz.qux", []string{
+		shData2, err := mockmodels.DummyStakeholderJSON("baz.qux", []string{
 			"https://baz.qux/iyoubhlkn/", "https://baz.foo/ukjhjtfyw/"})
 		require.NoError(t, err)
 
-		shFile2 := dummyJWSWrap(shData2)
+		shFile2 := mockmodels.DummyJWSWrap(shData2)
 		stakeholderServ2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, shFile2)
 		}))
 		defer stakeholderServ2.Close()
 
-		consortiumData, err := dummyConsortiumConfig("foo.bar", []config.StakeholderListElement{
+		consortiumData, err := mockmodels.DummyConsortiumJSON("foo.bar", []models.StakeholderListElement{
 			{
 				Domain: stakeholderServ1.URL,
 			},
@@ -51,30 +51,16 @@ func TestDiscoveryService_GetEndpoints(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		consortiumFile := dummyJWSWrap(consortiumData)
-
+		consFile := mockmodels.DummyJWSWrap(consortiumData)
 		consortiumServ := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprint(w, consortiumFile)
+			fmt.Fprint(w, consFile)
 		}))
-		defer consortiumServ.Close()
+		defer stakeholderServ2.Close()
 
-		s := NewService(WithTLSConfig(&tls.Config{}))
+		s := NewService(httpconfig.NewService(httpconfig.WithTLSConfig(&tls.Config{})))
 		endpoints, err := s.GetEndpoints(consortiumServ.URL)
 		require.NoError(t, err)
 		require.Len(t, endpoints, 4)
-		require.Equal(t, "https://bar.baz/webapi/123456", endpoints[0].URL)
-	})
-
-	t.Run("failure: consortium server failure", func(t *testing.T) {
-		consortiumServ := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(500)
-		}))
-		defer consortiumServ.Close()
-
-		s := NewService()
-		_, err := s.GetEndpoints(consortiumServ.URL)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "error 500")
 	})
 
 	t.Run("failure: stakeholder server failure", func(t *testing.T) {
@@ -83,233 +69,22 @@ func TestDiscoveryService_GetEndpoints(t *testing.T) {
 		}))
 		defer stakeholderServ.Close()
 
-		consortiumData, err := dummyConsortiumConfig("foo.bar", []config.StakeholderListElement{
+		consortiumData, err := mockmodels.DummyConsortiumJSON("foo.bar", []models.StakeholderListElement{
 			{
 				Domain: stakeholderServ.URL,
 			},
 		})
 		require.NoError(t, err)
 
-		consortiumFile := dummyJWSWrap(consortiumData)
-
-		consortiumServ := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		consortiumFile := mockmodels.DummyJWSWrap(consortiumData)
+		consortiumServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, consortiumFile)
 		}))
-		defer consortiumServ.Close()
+		defer consortiumServer.Close()
 
-		s := NewService()
-		_, err = s.GetEndpoints(consortiumServ.URL)
+		s := NewService(httpconfig.NewService(httpconfig.WithTLSConfig(&tls.Config{})))
+		_, err = s.GetEndpoints(consortiumServer.URL)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "stakeholder config request failed")
-	})
-}
-
-func TestDiscoveryService_getConsortiumData(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		consortiumData, err := dummyConsortiumConfig("foo.bar", []config.StakeholderListElement{
-			{
-				Domain: "bar.baz",
-			},
-			{
-				Domain: "baz.qux",
-			},
-		})
-		require.NoError(t, err)
-
-		consortiumFile := dummyJWSWrap(consortiumData)
-
-		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprint(w, consortiumFile)
-		}))
-		defer serv.Close()
-
-		ds := NewService()
-
-		conf, err := ds.getConsortium(serv.URL, "foo.bar")
-		require.NoError(t, err)
-
-		require.Equal(t, "foo.bar", conf.Config.Domain)
-	})
-
-	t.Run("failure: can't reach server", func(t *testing.T) {
-		ds := NewService()
-
-		_, err := ds.getConsortium("https://0.0.0.0:8080", "foo.bar")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "connection refused")
-	})
-
-	t.Run("failure: bad response", func(t *testing.T) {
-		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(500)
-		}))
-		defer serv.Close()
-
-		ds := NewService()
-
-		_, err := ds.getConsortium(serv.URL, "foo.bar")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "consortium config request failed")
-	})
-
-	t.Run("failure: empty response", func(t *testing.T) {
-		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-		defer serv.Close()
-
-		ds := NewService()
-
-		_, err := ds.getConsortium(serv.URL, "foo.bar")
-		require.Error(t, err)
-
-		require.Contains(t, err.Error(), "consortium config data should be a JWS")
-	})
-}
-
-func TestDiscoveryService_getStakeholderData(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		stakeholderData, err := dummyStakeholderConfig("foo.bar", []string{
-			"endpoint.website/go/here/",
-			"endpoint.website/here/too/",
-		})
-		require.NoError(t, err)
-
-		stakeholderFile := dummyJWSWrap(stakeholderData)
-
-		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprint(w, stakeholderFile)
-		}))
-		defer serv.Close()
-
-		ds := NewService()
-
-		conf, err := ds.getStakeholder(serv.URL, "foo.bar")
-		require.NoError(t, err)
-
-		require.Equal(t, "foo.bar", conf.Config.Domain)
-	})
-
-	t.Run("failure: can't reach server", func(t *testing.T) {
-		ds := NewService()
-
-		_, err := ds.getStakeholder("https://0.0.0.0:8080", "foo.bar")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "connection refused")
-	})
-
-	t.Run("failure: bad response", func(t *testing.T) {
-		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(500)
-		}))
-		defer serv.Close()
-
-		ds := NewService()
-
-		_, err := ds.getStakeholder(serv.URL, "foo.bar")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "stakeholder config request failed")
-	})
-
-	t.Run("failure: empty response", func(t *testing.T) {
-		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-		defer serv.Close()
-
-		ds := NewService()
-
-		_, err := ds.getStakeholder(serv.URL, "foo.bar")
-		require.Error(t, err)
-
-		require.Contains(t, err.Error(), "stakeholder config data should be a JWS")
-	})
-}
-
-func dummyJWSWrap(data string) string {
-	dataB64 := base64.RawURLEncoding.EncodeToString([]byte(data))
-	return `{"payload":"` + dataB64 + `","signatures":[{"header":{"kid":""}, "signature":""}]}`
-}
-
-func dummyConsortiumConfig(consortiumDomain string, stakeholders []config.StakeholderListElement) (string, error) {
-	cc := config.Consortium{
-		Domain:   consortiumDomain,
-		Policy:   config.ConsortiumPolicy{Cache: config.CacheControl{MaxAge: 0}},
-		Members:  stakeholders,
-		Previous: "",
-	}
-
-	out, err := json.Marshal(cc)
-	if err != nil {
-		return "", err
-	}
-
-	return string(out), nil
-}
-
-func dummyStakeholderConfig(stakeholderDomain string, endpoints []string) (string, error) {
-	sc := config.Stakeholder{
-		Domain:    stakeholderDomain,
-		DID:       "",
-		Policy:    config.StakeholderSettings{Cache: config.CacheControl{MaxAge: 0}},
-		Endpoints: endpoints,
-		Previous:  "",
-	}
-
-	out, err := json.Marshal(sc)
-	if err != nil {
-		return "", err
-	}
-
-	return string(out), nil
-}
-
-func Test_configURL(t *testing.T) {
-	tests := [][2]string{ // first element is the test value, second is the correct value
-		{
-			configURL("http://foo.example.com", "foo.example.com"),
-			"http://foo.example.com/.well-known/did-trustbloc/foo.example.com.json",
-		},
-		{ // adds http:// to the front of a domain
-			configURL("foo.example.com", "foo.example.com"),
-			"https://foo.example.com/.well-known/did-trustbloc/foo.example.com.json",
-		},
-		{ // doesn't work with full URLs in the domain field
-			configURL("foo.example.com", "http://foo.example.com"),
-			"https://foo.example.com/.well-known/did-trustbloc/http://foo.example.com.json",
-		},
-		{
-			configURL("http://foo.example.com", "bar.baz.qux"),
-			"http://foo.example.com/.well-known/did-trustbloc/bar.baz.qux.json",
-		},
-		{
-			configURL("a", "b"),
-			"https://a/.well-known/did-trustbloc/b.json",
-		},
-		{ // doesn't recognize urls that aren't http:// or https://
-			configURL("ws:abcdefg", "hijklmn"),
-			"https://ws:abcdefg/.well-known/did-trustbloc/hijklmn.json",
-		},
-		{ // doesn't work well with malformed urls
-			configURL("http:/abcdefg", "hijklmn"),
-			"https://http:/abcdefg/.well-known/did-trustbloc/hijklmn.json",
-		},
-	}
-
-	for _, test := range tests {
-		require.Equal(t, test[1], test[0])
-	}
-}
-
-func TestOpts(t *testing.T) {
-	t.Run("test opts", func(t *testing.T) {
-		// test WithTLSConfig
-		var opts []Option
-		opts = append(opts, WithTLSConfig(&tls.Config{ServerName: "test"}))
-
-		s := &DiscoveryService{}
-
-		// Apply options
-		for _, opt := range opts {
-			opt(s)
-		}
-
-		require.Equal(t, "test", s.tlsConfig.ServerName)
 	})
 }

--- a/pkg/vdri/trustbloc/endpoint/service.go
+++ b/pkg/vdri/trustbloc/endpoint/service.go
@@ -1,0 +1,52 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endpoint
+
+import (
+	"fmt"
+
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+type discovery interface {
+	GetEndpoints(domain string) ([]*models.Endpoint, error)
+}
+
+type selection interface {
+	SelectEndpoints(domain string, endpoints []*models.Endpoint) ([]*models.Endpoint, error)
+}
+
+// EndpointService uses discovery service and selection service to fetch and filter endpoints
+type EndpointService struct { // nolint: golint
+	discovery discovery
+	selection selection
+}
+
+// NewService create new EndpointService
+func NewService(d discovery, s selection) *EndpointService {
+	endpointService := &EndpointService{
+		discovery: d,
+		selection: s,
+	}
+
+	return endpointService
+}
+
+// GetEndpoints get a list of endpoints to use from a consortium at a given domain
+func (es *EndpointService) GetEndpoints(domain string) ([]*models.Endpoint, error) {
+	eps, err := es.discovery.GetEndpoints(domain)
+	if err != nil {
+		return nil, fmt.Errorf("discovery: %w", err)
+	}
+
+	out, err := es.selection.SelectEndpoints(domain, eps)
+	if err != nil {
+		return nil, fmt.Errorf("selection: %w", err)
+	}
+
+	return out, nil
+}

--- a/pkg/vdri/trustbloc/endpoint/service_test.go
+++ b/pkg/vdri/trustbloc/endpoint/service_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endpoint
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mockconfig "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/config"
+	mockdiscovery "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/discovery"
+	mockmodels "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/models"
+	mockselection "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/selection"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/config/httpconfig"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/discovery/staticdiscovery"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/selection/staticselection"
+)
+
+func TestEndpointService_GetEndpoints(t *testing.T) {
+	t.Run("success: get endpoints using static services", func(t *testing.T) {
+		shData1, err := mockmodels.DummyStakeholderJSON("bar.baz", []string{
+			"https://bar.baz/webapi/123456", "https://bar.baz/webapi/654321"})
+		require.NoError(t, err)
+
+		shFile1 := mockmodels.DummyJWSWrap(shData1)
+		stakeholderServ1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, shFile1)
+		}))
+		defer stakeholderServ1.Close()
+
+		shData2, err := mockmodels.DummyStakeholderJSON("baz.qux", []string{
+			"https://baz.qux/iyoubhlkn/", "https://baz.foo/ukjhjtfyw/"})
+		require.NoError(t, err)
+
+		shFile2 := mockmodels.DummyJWSWrap(shData2)
+		stakeholderServ2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, shFile2)
+		}))
+		defer stakeholderServ2.Close()
+
+		consortiumData, err := mockmodels.DummyConsortiumJSON("foo.bar", []models.StakeholderListElement{
+			{
+				Domain: stakeholderServ1.URL,
+			},
+			{
+				Domain: stakeholderServ2.URL,
+			},
+		})
+		require.NoError(t, err)
+
+		consortiumFile := mockmodels.DummyJWSWrap(consortiumData)
+
+		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, consortiumFile)
+		}))
+		defer serv.Close()
+
+		configService := httpconfig.NewService(httpconfig.WithTLSConfig(&tls.Config{}))
+		endpointService := NewService(staticdiscovery.NewService(configService), staticselection.NewService(configService))
+
+		endpoints, err := endpointService.GetEndpoints(serv.URL)
+		require.NoError(t, err)
+		require.Len(t, endpoints, 2)
+	})
+
+	t.Run("failure: config service stakeholder", func(t *testing.T) {
+		configService := &mockconfig.MockConfigService{
+			GetConsortiumFunc: func(s string, s2 string) (*models.ConsortiumFileData, error) {
+				return &models.ConsortiumFileData{
+					Config: &models.Consortium{
+						Members: []models.StakeholderListElement{{Domain: "foo"}},
+					},
+				}, nil
+			},
+			GetStakeholderFunc: func(s string, s2 string) (*models.StakeholderFileData, error) {
+				return nil, fmt.Errorf("stakeholder error")
+			}}
+
+		endpointService := NewService(staticdiscovery.NewService(configService), &mockselection.MockSelectionService{})
+
+		endpoints, err := endpointService.GetEndpoints("")
+		require.Error(t, err)
+		require.Nil(t, endpoints)
+		require.Contains(t, err.Error(), "stakeholder error")
+	})
+
+	t.Run("failure: discovery error", func(t *testing.T) {
+		endpointService := NewService(&mockdiscovery.MockDiscoveryService{
+			GetEndpointsFunc: func(domain string) ([]*models.Endpoint, error) {
+				return nil, fmt.Errorf("discovery error")
+			},
+		}, &mockselection.MockSelectionService{})
+
+		endpoints, err := endpointService.GetEndpoints("")
+		require.Error(t, err)
+		require.Nil(t, endpoints)
+		require.Contains(t, err.Error(), "discovery error")
+	})
+
+	t.Run("failure: selection", func(t *testing.T) {
+		endpointService := NewService(&mockdiscovery.MockDiscoveryService{}, &mockselection.MockSelectionService{
+			SelectEndpointsFunc: func(domain string, endpoints []*models.Endpoint) ([]*models.Endpoint, error) {
+				return nil, fmt.Errorf("selection error")
+			}})
+
+		endpoints, err := endpointService.GetEndpoints("")
+		require.Error(t, err)
+		require.Nil(t, endpoints)
+		require.Contains(t, err.Error(), "selection error")
+	})
+}

--- a/pkg/vdri/trustbloc/models/consortium.go
+++ b/pkg/vdri/trustbloc/models/consortium.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package config
+package models
 
 import (
 	"encoding/json"
@@ -38,7 +38,8 @@ type Consortium struct {
 
 // ConsortiumPolicy holds consortium policy configuration
 type ConsortiumPolicy struct {
-	Cache CacheControl `json:"cache"`
+	Cache      CacheControl `json:"cache"`
+	NumQueries int          `json:"num-queries"`
 }
 
 // CacheControl holds cache settings for this file,

--- a/pkg/vdri/trustbloc/models/consortium_test.go
+++ b/pkg/vdri/trustbloc/models/consortium_test.go
@@ -4,13 +4,15 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package config
+package models_test
 
 import (
-	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	mockmodels "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/models"
+	. "github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
 )
 
 // nolint: gochecknoglobals
@@ -34,14 +36,9 @@ var payload = `
 }
 `
 
-func dummyJWSWrap(data string) string {
-	dataB64 := base64.RawURLEncoding.EncodeToString([]byte(data))
-	return `{"payload":"` + dataB64 + `","signatures":[{"header":{"kid":""}, "signature":""}]}`
-}
-
 func Test_ParseConsortium(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		jws := dummyJWSWrap(payload)
+		jws := mockmodels.DummyJWSWrap(payload)
 
 		cData, err := ParseConsortium([]byte(jws))
 		require.NoError(t, err)
@@ -67,7 +64,7 @@ func Test_ParseConsortium(t *testing.T) {
 	})
 
 	t.Run("failure: malformed payload", func(t *testing.T) {
-		jws := dummyJWSWrap(`@@bad data@@`)
+		jws := mockmodels.DummyJWSWrap(`@@bad data@@`)
 
 		_, err := ParseConsortium([]byte(jws))
 		require.Error(t, err)

--- a/pkg/vdri/trustbloc/models/endpoint.go
+++ b/pkg/vdri/trustbloc/models/endpoint.go
@@ -3,7 +3,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package endpoint
+package models
 
 // Endpoint include info about endpoint
 type Endpoint struct {

--- a/pkg/vdri/trustbloc/models/stakeholder.go
+++ b/pkg/vdri/trustbloc/models/stakeholder.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package config
+package models
 
 import (
 	"encoding/json"

--- a/pkg/vdri/trustbloc/models/stakeholder_test.go
+++ b/pkg/vdri/trustbloc/models/stakeholder_test.go
@@ -4,12 +4,15 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package config
+package models_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	mockmodels "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/models"
+	. "github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
 )
 
 // nolint: gochecknoglobals
@@ -40,7 +43,7 @@ var exampleStakeholders = []string{`{
 
 func Test_ParseStakeholder(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		jws := dummyJWSWrap(exampleStakeholders[0])
+		jws := mockmodels.DummyJWSWrap(exampleStakeholders[0])
 
 		cData, err := ParseStakeholder([]byte(jws))
 		require.NoError(t, err)
@@ -57,7 +60,7 @@ func Test_ParseStakeholder(t *testing.T) {
 	})
 
 	t.Run("failure: malformed stakeholder within JWS", func(t *testing.T) {
-		jws := dummyJWSWrap(`{"bad":"data"`)
+		jws := mockmodels.DummyJWSWrap(`{"bad":"data"`)
 
 		_, err := ParseStakeholder([]byte(jws))
 		require.Error(t, err)

--- a/pkg/vdri/trustbloc/selection/staticselection/service_test.go
+++ b/pkg/vdri/trustbloc/selection/staticselection/service_test.go
@@ -10,15 +10,92 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/endpoint"
+	mockconfig "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/config"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
 )
+
+func intersectionSize(list, candidates []*models.Endpoint) int {
+	set := map[*models.Endpoint]struct{}{}
+
+	for _, ep := range list {
+		set[ep] = struct{}{}
+	}
+
+	count := 0
+
+	for _, ep := range candidates {
+		if _, present := set[ep]; present {
+			count++
+		}
+	}
+
+	return count
+}
 
 func TestSelectionService_SelectEndpoints(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
-		s := NewService()
-		endpoints, err := s.SelectEndpoints([]*endpoint.Endpoint{{URL: "url"}})
+		s := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(s string, s2 string) (*models.ConsortiumFileData, error) {
+				return &models.ConsortiumFileData{
+					Config: &models.Consortium{
+						Policy: models.ConsortiumPolicy{NumQueries: 0},
+					},
+				}, nil
+			},
+		})
+
+		endpoints, err := s.SelectEndpoints("domain", []*models.Endpoint{{URL: "url"}})
 		require.NoError(t, err)
 		require.Len(t, endpoints, 1)
 		require.Equal(t, "url", endpoints[0].URL)
+	})
+
+	t.Run("test success - repeat domains", func(t *testing.T) {
+		endpoints1 := []*models.Endpoint{
+			{URL: "url.1", Domain: "1"},
+			{URL: "url.2", Domain: "1"},
+		}
+
+		endpoints2 := []*models.Endpoint{
+			{URL: "url.3", Domain: "2"},
+			{URL: "url.4", Domain: "2"},
+		}
+
+		s := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(s string, s2 string) (*models.ConsortiumFileData, error) {
+				return &models.ConsortiumFileData{
+					Config: &models.Consortium{},
+				}, nil
+			}})
+
+		selectedEndpoints, err := s.SelectEndpoints("domain", append(endpoints1, endpoints2...))
+		require.NoError(t, err)
+		require.Len(t, selectedEndpoints, 2)
+		require.Equal(t, 1, intersectionSize(selectedEndpoints, endpoints1))
+		require.Equal(t, 1, intersectionSize(selectedEndpoints, endpoints2))
+	})
+
+	t.Run("test success - M of N", func(t *testing.T) {
+		s := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(s string, s2 string) (*models.ConsortiumFileData, error) {
+				return &models.ConsortiumFileData{
+					Config: &models.Consortium{
+						Policy: models.ConsortiumPolicy{NumQueries: 2},
+					},
+				}, nil
+			}})
+
+		endpoints := []*models.Endpoint{
+			{URL: "url.1", Domain: "1"},
+			{URL: "url.2", Domain: "2"},
+			{URL: "url.3", Domain: "3"},
+			{URL: "url.4", Domain: "4"},
+		}
+
+		selectedEndpoints, err := s.SelectEndpoints("domain", endpoints)
+
+		require.NoError(t, err)
+		require.Len(t, selectedEndpoints, 2)
+		require.Equal(t, 2, intersectionSize(selectedEndpoints, endpoints))
 	})
 }

--- a/pkg/vdri/trustbloc/vdri_test.go
+++ b/pkg/vdri/trustbloc/vdri_test.go
@@ -16,9 +16,8 @@ import (
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/mock/vdri"
 	"github.com/stretchr/testify/require"
 
-	mockdiscovery "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/discovery"
-	mockselection "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/selection"
-	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/endpoint"
+	mockendpoint "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/endpoint"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
 )
 
 func TestVDRI_Accept(t *testing.T) {
@@ -115,8 +114,8 @@ func TestVDRI_Read(t *testing.T) {
 	t.Run("test error from get endpoints", func(t *testing.T) {
 		v := New()
 
-		v.discovery = &mockdiscovery.MockDiscoveryService{
-			GetEndpointsFunc: func(domain string) (endpoints []*endpoint.Endpoint, err error) {
+		v.endpointService = &mockendpoint.MockEndpointService{
+			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
 				return nil, fmt.Errorf("discover error")
 			}}
 
@@ -125,12 +124,8 @@ func TestVDRI_Read(t *testing.T) {
 		require.Contains(t, err.Error(), "discover error")
 		require.Nil(t, doc)
 
-		v.discovery = &mockdiscovery.MockDiscoveryService{
-			GetEndpointsFunc: func(domain string) (endpoints []*endpoint.Endpoint, err error) {
-				return nil, nil
-			}}
-		v.selection = &mockselection.MockSelectionService{
-			SelectEndpointsFunc: func(endpoint []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+		v.endpointService = &mockendpoint.MockEndpointService{
+			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
 				return nil, fmt.Errorf("select error")
 			}}
 
@@ -139,8 +134,8 @@ func TestVDRI_Read(t *testing.T) {
 		require.Contains(t, err.Error(), "select error")
 		require.Nil(t, doc)
 
-		v.selection = &mockselection.MockSelectionService{
-			SelectEndpointsFunc: func(endpoint []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+		v.endpointService = &mockendpoint.MockEndpointService{
+			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
 				return nil, nil
 			}}
 
@@ -153,9 +148,9 @@ func TestVDRI_Read(t *testing.T) {
 	t.Run("test error from get http vdri", func(t *testing.T) {
 		v := New()
 
-		v.discovery = &mockdiscovery.MockDiscoveryService{
-			GetEndpointsFunc: func(domain string) (endpoints []*endpoint.Endpoint, err error) {
-				return []*endpoint.Endpoint{{URL: "url"}}, nil
+		v.endpointService = &mockendpoint.MockEndpointService{
+			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
+				return []*models.Endpoint{{URL: "url"}}, nil
 			}}
 
 		v.getHTTPVDRI = func(url string) (v vdri, err error) {
@@ -171,9 +166,9 @@ func TestVDRI_Read(t *testing.T) {
 	t.Run("test error from http vdri read", func(t *testing.T) {
 		v := New()
 
-		v.discovery = &mockdiscovery.MockDiscoveryService{
-			GetEndpointsFunc: func(domain string) (endpoints []*endpoint.Endpoint, err error) {
-				return []*endpoint.Endpoint{{URL: "url"}}, nil
+		v.endpointService = &mockendpoint.MockEndpointService{
+			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
+				return []*models.Endpoint{{URL: "url"}}, nil
 			}}
 
 		v.getHTTPVDRI = func(url string) (v vdri, err error) {
@@ -192,9 +187,9 @@ func TestVDRI_Read(t *testing.T) {
 	t.Run("test error from mismatch", func(t *testing.T) {
 		v := New()
 
-		v.discovery = &mockdiscovery.MockDiscoveryService{
-			GetEndpointsFunc: func(domain string) (endpoints []*endpoint.Endpoint, err error) {
-				return []*endpoint.Endpoint{{URL: "url"}, {URL: "url.2"}}, nil
+		v.endpointService = &mockendpoint.MockEndpointService{
+			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
+				return []*models.Endpoint{{URL: "url"}, {URL: "url.2"}}, nil
 			}}
 
 		counter := 0
@@ -215,9 +210,9 @@ func TestVDRI_Read(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		v := New()
 
-		v.discovery = &mockdiscovery.MockDiscoveryService{
-			GetEndpointsFunc: func(domain string) (endpoints []*endpoint.Endpoint, err error) {
-				return []*endpoint.Endpoint{{URL: "url"}, {URL: "url.2"}}, nil
+		v.endpointService = &mockendpoint.MockEndpointService{
+			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
+				return []*models.Endpoint{{URL: "url"}, {URL: "url.2"}}, nil
 			}}
 
 		v.getHTTPVDRI = func(url string) (v vdri, err error) {

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -280,8 +280,6 @@ github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4/go.mod 
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.3-0.20200414165955-488d2227b903 h1:dwQ/dpxPGLqcRzpw0CrGFJJrbPT1iXprL1eYlsjISP0=
 github.com/trustbloc/edge-core v0.1.3-0.20200414165955-488d2227b903/go.mod h1:mmgEfSIoNjshnVdxEtPwh2CLs0EaBaaejgI2KNsOEOE=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200420172101-c406dfdf4db2 h1:a71TwYN8gqN0e0V22xFJEa5eikvb8wbOjtmb2//Qt/M=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200420172101-c406dfdf4db2/go.mod h1:4Z1Zrxs/ut+fGmTdliYAc6sVueXb07EFJHKC/5VOvQA=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200420215423-0c6a32299a30 h1:bd/u3vgi2ZGYBenKTooTV9FiYMfIkhzCTXt/nAUiDmg=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200420215423-0c6a32299a30/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
Also refactors client-side services:
- Split config-fetching service out of discovery service
- Made discovery service consume config service and selection service
  (instead of clients consuming all three, passing data between them)
- Clients only need to use the discovery service API `GetEndpoints(domain)`

Fixes #37

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>