### PR TITLE
feat: Verifying config service

### DIFF
--- a/cmd/did-method-rest/go.mod
+++ b/cmd/did-method-rest/go.mod
@@ -8,7 +8,6 @@ replace github.com/trustbloc/trustbloc-did-method => ../..
 
 require (
 	github.com/gorilla/mux v1.7.4
-	github.com/hyperledger/aries-framework-go v0.1.3-0.20200430150510-b5d30427f098
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.5.1
 	github.com/trustbloc/edge-core v0.1.3-0.20200414220734-842cc197e692

--- a/pkg/internal/mock/config/mock_service.go
+++ b/pkg/internal/mock/config/mock_service.go
@@ -26,7 +26,7 @@ func (m *MockConfigService) GetConsortium(url, domain string) (*models.Consortiu
 
 // GetStakeholder get the stakeholder config file for a given domain from the given url
 func (m *MockConfigService) GetStakeholder(url, domain string) (*models.StakeholderFileData, error) {
-	if m.GetConsortiumFunc != nil {
+	if m.GetStakeholderFunc != nil {
 		return m.GetStakeholderFunc(url, domain)
 	}
 

--- a/pkg/internal/mock/models/mock_models.go
+++ b/pkg/internal/mock/models/mock_models.go
@@ -37,23 +37,48 @@ func DummyConsortiumJSON(consortiumDomain string, stakeholders []models.Stakehol
 		return "", err
 	}
 
-	return string(out), nil
+	return DummyJWSWrap(string(out)), nil
 }
 
-// DummyStakeholderJSON creates a dummy stakeholder JSON config
-func DummyStakeholderJSON(stakeholderDomain string, endpoints []string) (string, error) {
-	sc := models.Stakeholder{
+// WrapConsortium marshals a consortium to JSON and wraps it in a dummy JWS
+func WrapConsortium(consortium *models.Consortium) (string, error) {
+	out, err := json.Marshal(consortium)
+	if err != nil {
+		return "", err
+	}
+
+	return DummyJWSWrap(string(out)), nil
+}
+
+// WrapStakeholder marshals a stakeholder to JSON and wraps it in a dummy JWS
+func WrapStakeholder(stakeholder *models.Stakeholder) (string, error) {
+	out, err := json.Marshal(stakeholder)
+	if err != nil {
+		return "", err
+	}
+
+	return DummyJWSWrap(string(out)), nil
+}
+
+// DummyStakeholder creates a dummy stakeholder JSON config
+func DummyStakeholder(stakeholderDomain string, endpoints []string) *models.Stakeholder {
+	return &models.Stakeholder{
 		Domain:    stakeholderDomain,
 		DID:       "",
 		Policy:    models.StakeholderSettings{Cache: models.CacheControl{MaxAge: 0}},
 		Endpoints: endpoints,
 		Previous:  "",
 	}
+}
+
+// DummyStakeholderJSON creates a dummy stakeholder JSON config
+func DummyStakeholderJSON(stakeholderDomain string, endpoints []string) (string, error) {
+	sc := DummyStakeholder(stakeholderDomain, endpoints)
 
 	out, err := json.Marshal(sc)
 	if err != nil {
 		return "", err
 	}
 
-	return string(out), nil
+	return DummyJWSWrap(string(out)), nil
 }

--- a/pkg/vdri/trustbloc/config/httpconfig/service_test.go
+++ b/pkg/vdri/trustbloc/config/httpconfig/service_test.go
@@ -18,9 +18,9 @@ import (
 	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
 )
 
-func TestDiscoveryService_getConsortiumData(t *testing.T) {
+func TestConfigService_GetConsortium(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		consortiumData, err := mockmodels.DummyConsortiumJSON("foo.bar", []models.StakeholderListElement{
+		consortium := mockmodels.DummyConsortium("foo.bar", []models.StakeholderListElement{
 			{
 				Domain: "bar.baz",
 			},
@@ -28,9 +28,9 @@ func TestDiscoveryService_getConsortiumData(t *testing.T) {
 				Domain: "baz.qux",
 			},
 		})
-		require.NoError(t, err)
 
-		consortiumFile := mockmodels.DummyJWSWrap(consortiumData)
+		consortiumFile, err := mockmodels.WrapConsortium(consortium)
+		require.NoError(t, err)
 
 		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, consortiumFile)
@@ -79,15 +79,15 @@ func TestDiscoveryService_getConsortiumData(t *testing.T) {
 	})
 }
 
-func TestDiscoveryService_getStakeholderData(t *testing.T) {
+func TestConfigService_GetStakeholder(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		stakeholderData, err := mockmodels.DummyStakeholderJSON("foo.bar", []string{
+		stakeholder := mockmodels.DummyStakeholder("foo.bar", []string{
 			"endpoint.website/go/here/",
 			"endpoint.website/here/too/",
 		})
-		require.NoError(t, err)
 
-		stakeholderFile := mockmodels.DummyJWSWrap(stakeholderData)
+		stakeholderFile, err := mockmodels.WrapStakeholder(stakeholder)
+		require.NoError(t, err)
 
 		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, stakeholderFile)

--- a/pkg/vdri/trustbloc/config/verifyingconfig/service.go
+++ b/pkg/vdri/trustbloc/config/verifyingconfig/service.go
@@ -1,0 +1,85 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifyingconfig
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+type config interface {
+	GetConsortium(string, string) (*models.ConsortiumFileData, error)
+	GetStakeholder(string, string) (*models.StakeholderFileData, error)
+}
+
+// ConfigService fetches consortium and stakeholder configs over http
+type ConfigService struct {
+	config config
+}
+
+// NewService create new ConfigService
+func NewService(config config) *ConfigService {
+	configService := &ConfigService{config: config}
+
+	return configService
+}
+
+// GetConsortium fetches and parses the consortium file at the given domain
+func (cs *ConfigService) GetConsortium(url, domain string) (*models.ConsortiumFileData, error) {
+	consortiumData, err := cs.config.GetConsortium(url, domain)
+	if err != nil {
+		return nil, fmt.Errorf("wrapped config service: %w", err)
+	}
+
+	consortium := consortiumData.Config
+	if consortium == nil {
+		return nil, fmt.Errorf("consortium is nil")
+	}
+
+	n := consortium.Policy.NumQueries
+
+	// if ds.numStakeholders is 0, then we use all stakeholders
+	if n == 0 {
+		n = len(consortium.Members)
+	}
+
+	perm := rand.Perm(len(consortium.Members))
+
+	// number of stakeholders that have verified
+	verifiedCount := 0
+
+	for i := 0; i < n; i++ {
+		stakeholder := consortium.Members[perm[i]].Domain
+		// get consortium file from stakeholder server
+		file, err := cs.config.GetConsortium(stakeholder, domain)
+		if err != nil {
+			log.Warnf("stakeholder peer failed to return consortium config")
+			continue // skip failed stakeholders
+		}
+
+		if !bytes.Equal(file.JWS.UnsafePayloadWithoutVerification(), consortiumData.JWS.UnsafePayloadWithoutVerification()) {
+			continue
+		}
+
+		verifiedCount++
+	}
+
+	if verifiedCount < n {
+		return nil, fmt.Errorf("insufficient stakeholder endorsement of consortium config file")
+	}
+
+	return consortiumData, nil
+}
+
+// GetStakeholder returns the stakeholder config file fetched by the wrapped config service
+func (cs *ConfigService) GetStakeholder(url, domain string) (*models.StakeholderFileData, error) {
+	return cs.config.GetStakeholder(url, domain)
+}

--- a/pkg/vdri/trustbloc/config/verifyingconfig/service_test.go
+++ b/pkg/vdri/trustbloc/config/verifyingconfig/service_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifyingconfig
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mockconfig "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/config"
+	mockmodels "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/models"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/config/httpconfig"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+func TestConfigService_GetConsortium(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		consortiumFile := ""
+
+		cServ := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, consortiumFile)
+		}))
+		defer cServ.Close()
+
+		s1Serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, consortiumFile)
+		}))
+		defer s1Serv.Close()
+
+		s2Serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, consortiumFile)
+		}))
+		defer s2Serv.Close()
+
+		var err error
+
+		consortiumFile, err = mockmodels.DummyConsortiumJSON("foo.bar", []models.StakeholderListElement{
+			{
+				Domain: s1Serv.URL,
+			},
+			{
+				Domain: s2Serv.URL,
+			},
+		})
+		require.NoError(t, err)
+
+		cs := NewService(httpconfig.NewService())
+
+		conf, err := cs.GetConsortium(cServ.URL, "foo.bar")
+		require.NoError(t, err)
+
+		require.Equal(t, "foo.bar", conf.Config.Domain)
+	})
+
+	t.Run("failure - one stakeholder server disagrees", func(t *testing.T) {
+		consortiumFile := ""
+
+		cServ := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, consortiumFile)
+		}))
+		defer cServ.Close()
+
+		s1Serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, consortiumFile)
+		}))
+		defer s1Serv.Close()
+
+		wrongFile, err := mockmodels.DummyConsortiumJSON("wrong.file", nil)
+		require.NoError(t, err)
+
+		s2Serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, wrongFile)
+		}))
+		defer s2Serv.Close()
+
+		consortiumFile, err = mockmodels.DummyConsortiumJSON("foo.bar", []models.StakeholderListElement{
+			{
+				Domain: s1Serv.URL,
+			},
+			{
+				Domain: s2Serv.URL,
+			},
+		})
+		require.NoError(t, err)
+
+		cs := NewService(httpconfig.NewService())
+
+		_, err = cs.GetConsortium(cServ.URL, "foo.bar")
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), "endorsement")
+	})
+
+	t.Run("success - one stakeholder server disagrees, only one needs to agree", func(t *testing.T) {
+		consortiumFile := ""
+
+		cServ := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, consortiumFile)
+		}))
+		defer cServ.Close()
+
+		s1Serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, consortiumFile)
+		}))
+		defer s1Serv.Close()
+
+		s2Serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "foo bar")
+		}))
+		defer s2Serv.Close()
+
+		var err error
+
+		consortium := mockmodels.DummyConsortium("foo.bar", []models.StakeholderListElement{
+			{
+				Domain: s1Serv.URL,
+			},
+			{
+				Domain: s2Serv.URL,
+			}})
+
+		// only require one stakeholder to endorse
+		consortium.Policy.NumQueries = 1
+
+		consortiumFile, err = mockmodels.WrapConsortium(consortium)
+		require.NoError(t, err)
+
+		cs := NewService(httpconfig.NewService())
+
+		_, err = cs.GetConsortium(cServ.URL, "foo.bar")
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), "endorsement")
+	})
+
+	t.Run("failure - errors fetching consortium", func(t *testing.T) {
+		cs := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(u string, d string) (*models.ConsortiumFileData, error) {
+				return nil, fmt.Errorf("consortium error")
+			}})
+
+		_, err := cs.GetConsortium("foo", "foo")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "consortium error")
+
+		cs = NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(u string, d string) (*models.ConsortiumFileData, error) {
+				return &models.ConsortiumFileData{}, nil
+			}})
+
+		_, err = cs.GetConsortium("foo", "foo")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "consortium is nil")
+	})
+}
+
+func TestConfigService_GetStakeholder(t *testing.T) {
+	t.Run("pass through", func(t *testing.T) {
+		cs := NewService(&mockconfig.MockConfigService{
+			GetStakeholderFunc: func(s string, s2 string) (*models.StakeholderFileData, error) {
+				return &models.StakeholderFileData{Config: &models.Stakeholder{Domain: "foo"}}, fmt.Errorf("foo error")
+			}})
+
+		conf, err := cs.GetStakeholder("foo.bar", "foo.bar")
+		// verify error is passed through
+		require.Error(t, err)
+		require.EqualError(t, err, "foo error")
+
+		// verify return value is passed through
+		require.NotNil(t, conf)
+		require.NotNil(t, conf.Config)
+		require.Equal(t, conf.Config.Domain, "foo")
+	})
+}

--- a/pkg/vdri/trustbloc/discovery/staticdiscovery/service_test.go
+++ b/pkg/vdri/trustbloc/discovery/staticdiscovery/service_test.go
@@ -21,21 +21,19 @@ import (
 
 func TestDiscoveryService_GetEndpoints(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		shData1, err := mockmodels.DummyStakeholderJSON("bar.baz", []string{
+		shFile1, err := mockmodels.DummyStakeholderJSON("bar.baz", []string{
 			"https://bar.baz/webapi/123456", "https://bar.baz/webapi/654321"})
 		require.NoError(t, err)
 
-		shFile1 := mockmodels.DummyJWSWrap(shData1)
 		stakeholderServ1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, shFile1)
 		}))
 		defer stakeholderServ1.Close()
 
-		shData2, err := mockmodels.DummyStakeholderJSON("baz.qux", []string{
+		shFile2, err := mockmodels.DummyStakeholderJSON("baz.qux", []string{
 			"https://baz.qux/iyoubhlkn/", "https://baz.foo/ukjhjtfyw/"})
 		require.NoError(t, err)
 
-		shFile2 := mockmodels.DummyJWSWrap(shData2)
 		stakeholderServ2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, shFile2)
 		}))
@@ -51,9 +49,8 @@ func TestDiscoveryService_GetEndpoints(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		consFile := mockmodels.DummyJWSWrap(consortiumData)
 		consortiumServ := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprint(w, consFile)
+			fmt.Fprint(w, consortiumData)
 		}))
 		defer stakeholderServ2.Close()
 
@@ -69,14 +66,13 @@ func TestDiscoveryService_GetEndpoints(t *testing.T) {
 		}))
 		defer stakeholderServ.Close()
 
-		consortiumData, err := mockmodels.DummyConsortiumJSON("foo.bar", []models.StakeholderListElement{
+		consortiumFile, err := mockmodels.DummyConsortiumJSON("foo.bar", []models.StakeholderListElement{
 			{
 				Domain: stakeholderServ.URL,
 			},
 		})
 		require.NoError(t, err)
 
-		consortiumFile := mockmodels.DummyJWSWrap(consortiumData)
 		consortiumServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, consortiumFile)
 		}))

--- a/pkg/vdri/trustbloc/endpoint/service_test.go
+++ b/pkg/vdri/trustbloc/endpoint/service_test.go
@@ -27,27 +27,25 @@ import (
 
 func TestEndpointService_GetEndpoints(t *testing.T) {
 	t.Run("success: get endpoints using static services", func(t *testing.T) {
-		shData1, err := mockmodels.DummyStakeholderJSON("bar.baz", []string{
+		shFile1, err := mockmodels.DummyStakeholderJSON("bar.baz", []string{
 			"https://bar.baz/webapi/123456", "https://bar.baz/webapi/654321"})
 		require.NoError(t, err)
 
-		shFile1 := mockmodels.DummyJWSWrap(shData1)
 		stakeholderServ1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, shFile1)
 		}))
 		defer stakeholderServ1.Close()
 
-		shData2, err := mockmodels.DummyStakeholderJSON("baz.qux", []string{
+		shFile2, err := mockmodels.DummyStakeholderJSON("baz.qux", []string{
 			"https://baz.qux/iyoubhlkn/", "https://baz.foo/ukjhjtfyw/"})
 		require.NoError(t, err)
 
-		shFile2 := mockmodels.DummyJWSWrap(shData2)
 		stakeholderServ2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, shFile2)
 		}))
 		defer stakeholderServ2.Close()
 
-		consortiumData, err := mockmodels.DummyConsortiumJSON("foo.bar", []models.StakeholderListElement{
+		consortiumFile, err := mockmodels.DummyConsortiumJSON("foo.bar", []models.StakeholderListElement{
 			{
 				Domain: stakeholderServ1.URL,
 			},
@@ -56,8 +54,6 @@ func TestEndpointService_GetEndpoints(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-
-		consortiumFile := mockmodels.DummyJWSWrap(consortiumData)
 
 		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, consortiumFile)

--- a/pkg/vdri/trustbloc/vdri.go
+++ b/pkg/vdri/trustbloc/vdri.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/vdri/httpbinding"
 
 	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/config/httpconfig"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/config/verifyingconfig"
 	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/discovery/staticdiscovery"
 	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/endpoint"
 	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
@@ -50,9 +51,10 @@ func New(opts ...Option) *VDRI {
 	}
 
 	configService := httpconfig.NewService(httpconfig.WithTLSConfig(v.tlsConfig))
+	verifyingService := verifyingconfig.NewService(configService)
 	v.endpointService = endpoint.NewService(
-		staticdiscovery.NewService(configService),
-		staticselection.NewService(configService))
+		staticdiscovery.NewService(verifyingService),
+		staticselection.NewService(verifyingService))
 
 	v.getHTTPVDRI = func(url string) (vdri, error) {
 		return httpbinding.New(url,

--- a/test/bdd/fixtures/stakeholder-server/config-data/testnet.trustbloc.local.json
+++ b/test/bdd/fixtures/stakeholder-server/config-data/testnet.trustbloc.local.json
@@ -1,0 +1,13 @@
+{
+  "domain": "consortium",
+  "did": "did:trustbloc:testnet.trustbloc.local:zQ1234567890987654321",
+  "policy": {
+    "cache": {"max_age": 123456789}
+  },
+  "members": [
+    {
+      "domain": "stakeholder.one:8088"
+    }
+  ],
+  "previous": ""
+}


### PR DESCRIPTION
Verifying Config Service wraps a config service, calling it to fetch the consortium config from each stakeholder to cross-validate.

Fixes #27

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>