### PR TITLE
WIP: Memory Caching Config Service

### DIFF
--- a/pkg/vdri/trustbloc/config/memorycacheconfig/service.go
+++ b/pkg/vdri/trustbloc/config/memorycacheconfig/service.go
@@ -1,0 +1,117 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memorycacheconfig
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+type consortiumCacheEntry struct {
+	data   *models.ConsortiumFileData
+	expiry time.Time
+}
+
+type stakeholderCacheEntry struct {
+	data   *models.StakeholderFileData
+	expiry time.Time
+}
+
+type config interface {
+	GetConsortium(string, string) (*models.ConsortiumFileData, error)
+	GetStakeholder(string, string) (*models.StakeholderFileData, error)
+}
+
+// ConfigService fetches consortium and stakeholder configs using a wrapped config service, caching results in-memory
+type ConfigService struct {
+	config config
+
+	//	TODO: temp-cache consortium configs
+	consortiumCache map[string]*consortiumCacheEntry
+	//	TODO: temp-cache stakeholder configs
+	stakeholderCache map[string]*stakeholderCacheEntry
+}
+
+// NewService create new ConfigService
+func NewService(config config) *ConfigService {
+	configService := &ConfigService{
+		config:           config,
+		consortiumCache:  map[string]*consortiumCacheEntry{},
+		stakeholderCache: map[string]*stakeholderCacheEntry{},
+	}
+
+	return configService
+}
+
+// GetConsortium fetches and parses the consortium file at the given domain, caching the value
+func (cs *ConfigService) GetConsortium(url, domain string) (*models.ConsortiumFileData, error) { // nolint: dupl
+	if val, ok := cs.consortiumCache[domain]; ok {
+		if time.Now().Before(val.expiry) {
+			return val.data, nil
+		}
+	}
+
+	consortiumData, err := cs.config.GetConsortium(url, domain)
+	if err != nil {
+		return nil, fmt.Errorf("wrapped config service: %w", err)
+	}
+
+	fetchTime := time.Now()
+
+	consortium := consortiumData.Config
+	if consortium == nil {
+		return nil, fmt.Errorf("nil consortium")
+	}
+
+	if consortium.Policy.Cache.MaxAge > 0 {
+		expiryTime := fetchTime.Add(time.Duration(consortium.Policy.Cache.MaxAge) * time.Second)
+
+		newEntry := consortiumCacheEntry{
+			data:   consortiumData,
+			expiry: expiryTime,
+		}
+
+		cs.consortiumCache[domain] = &newEntry
+	}
+
+	return consortiumData, nil
+}
+
+// GetStakeholder returns the stakeholder config file fetched by the wrapped config service, caching the value
+func (cs *ConfigService) GetStakeholder(url, domain string) (*models.StakeholderFileData, error) { // nolint: dupl
+	if val, ok := cs.stakeholderCache[domain]; ok {
+		if time.Now().Before(val.expiry) {
+			return val.data, nil
+		}
+	}
+
+	stakeholderData, err := cs.config.GetStakeholder(url, domain)
+	if err != nil {
+		return nil, fmt.Errorf("wrapped config service: %w", err)
+	}
+
+	fetchTime := time.Now()
+
+	stakeholder := stakeholderData.Config
+	if stakeholder == nil {
+		return nil, fmt.Errorf("nil stakeholder")
+	}
+
+	if stakeholder.Policy.Cache.MaxAge > 0 {
+		expiryTime := fetchTime.Add(time.Duration(stakeholder.Policy.Cache.MaxAge) * time.Second)
+
+		newEntry := stakeholderCacheEntry{
+			data:   stakeholderData,
+			expiry: expiryTime,
+		}
+
+		cs.stakeholderCache[domain] = &newEntry
+	}
+
+	return stakeholderData, nil
+}

--- a/pkg/vdri/trustbloc/config/memorycacheconfig/service_test.go
+++ b/pkg/vdri/trustbloc/config/memorycacheconfig/service_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memorycacheconfig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mockconfig "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/config"
+	mockmodels "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/models"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+func TestConfigService_GetConsortium(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		consortiumData := mockmodels.DummyConsortium("foo.bar", []models.StakeholderListElement{
+			{
+				Domain: "bar.baz",
+			},
+			{
+				Domain: "baz.qux",
+			},
+		})
+		cs := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(u string, d string) (*models.ConsortiumFileData, error) {
+				return &models.ConsortiumFileData{Config: consortiumData}, nil
+			}})
+
+		conf, err := cs.GetConsortium("foo.bar", "foo.bar")
+		require.NoError(t, err)
+
+		require.Equal(t, "foo.bar", conf.Config.Domain)
+	})
+
+	t.Run("success - demonstrate caching", func(t *testing.T) {
+		consortiumData := mockmodels.DummyConsortium("foo.bar", []models.StakeholderListElement{
+			{
+				Domain: "bar.baz",
+			},
+			{
+				Domain: "baz.qux",
+			},
+		})
+
+		// Note: this test will fail if it takes more than 1000 seconds, meaning the cache stales
+		consortiumData.Policy.Cache.MaxAge = 1000
+
+		callCount := 0
+
+		cs := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(u string, d string) (*models.ConsortiumFileData, error) {
+				callCount++
+				if callCount > 1 {
+					return nil, fmt.Errorf("double-call")
+				}
+
+				return &models.ConsortiumFileData{Config: consortiumData}, nil
+			}})
+
+		// Call multiple times, which should fail if the wrapped service is called multiple times
+		// indicating that there's no caching
+		for i := 0; i < 5; i++ {
+			conf, err := cs.GetConsortium("foo.bar", "foo.bar")
+			require.NoError(t, err)
+
+			require.Equal(t, "foo.bar", conf.Config.Domain)
+		}
+	})
+
+	t.Run("success - re-call wrapped service when cache times out", func(t *testing.T) {
+		consortiumData := mockmodels.DummyConsortium("foo.bar", []models.StakeholderListElement{
+			{
+				Domain: "bar.baz",
+			},
+			{
+				Domain: "baz.qux",
+			},
+		})
+
+		consortiumData.Policy.Cache.MaxAge = 0
+
+		callCount := 0
+
+		cs := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(u string, d string) (*models.ConsortiumFileData, error) {
+				callCount++
+				if callCount > 1 {
+					return nil, fmt.Errorf("double-call")
+				}
+
+				return &models.ConsortiumFileData{Config: consortiumData}, nil
+			}})
+
+		// Call multiple times, which should fail if the wrapped service is called multiple times
+		// indicating that there's no caching
+		conf, err := cs.GetConsortium("foo.bar", "foo.bar")
+		require.NoError(t, err)
+
+		require.Equal(t, "foo.bar", conf.Config.Domain)
+
+		_, err = cs.GetConsortium("foo.bar", "foo.bar")
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), "double-call")
+	})
+
+	t.Run("failure - nil pointer", func(t *testing.T) {
+		cs := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(u string, d string) (*models.ConsortiumFileData, error) {
+				return &models.ConsortiumFileData{Config: nil}, nil
+			}})
+
+		_, err := cs.GetConsortium("foo.bar", "foo.bar")
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), "nil")
+	})
+}
+
+func TestConfigService_GetStakeholder(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		stakeholder := mockmodels.DummyStakeholder("foo.bar", []string{
+			"endpoint.website/go/here/",
+			"endpoint.website/here/too/",
+		})
+
+		cs := NewService(&mockconfig.MockConfigService{
+			GetStakeholderFunc: func(u string, d string) (*models.StakeholderFileData, error) {
+				return &models.StakeholderFileData{Config: stakeholder}, nil
+			}})
+
+		conf, err := cs.GetStakeholder("foo.bar", "foo.bar")
+		require.NoError(t, err)
+
+		require.Equal(t, "foo.bar", conf.Config.Domain)
+	})
+
+	t.Run("success - demonstrate caching", func(t *testing.T) {
+		stakeholder := mockmodels.DummyStakeholder("foo.bar", []string{"foo", "bar"})
+
+		// Note: this test will fail if it takes more than 1000 seconds, meaning the cache stales
+		stakeholder.Policy.Cache.MaxAge = 1000
+
+		callCount := 0
+
+		cs := NewService(&mockconfig.MockConfigService{
+			GetStakeholderFunc: func(u string, d string) (*models.StakeholderFileData, error) {
+				callCount++
+				if callCount > 1 {
+					return nil, fmt.Errorf("double-call")
+				}
+
+				return &models.StakeholderFileData{Config: stakeholder}, nil
+			}})
+
+		// Call multiple times, which should fail if the wrapped service is called multiple times
+		// indicating that there's no caching
+		for i := 0; i < 5; i++ {
+			conf, err := cs.GetStakeholder("foo.bar", "foo.bar")
+			require.NoError(t, err)
+
+			require.Equal(t, "foo.bar", conf.Config.Domain)
+		}
+	})
+
+	t.Run("success - re-call wrapped service when cache times out", func(t *testing.T) {
+		stakeholder := mockmodels.DummyStakeholder("foo.bar", []string{"foo", "bar"})
+
+		stakeholder.Policy.Cache.MaxAge = 0
+
+		callCount := 0
+
+		cs := NewService(&mockconfig.MockConfigService{
+			GetStakeholderFunc: func(u string, d string) (*models.StakeholderFileData, error) {
+				callCount++
+				if callCount > 1 {
+					return nil, fmt.Errorf("double-call")
+				}
+
+				return &models.StakeholderFileData{Config: stakeholder}, nil
+			}})
+
+		// Call multiple times, which should fail if the wrapped service is called multiple times
+		// indicating that there's no caching
+		conf, err := cs.GetStakeholder("foo.bar", "foo.bar")
+		require.NoError(t, err)
+
+		require.Equal(t, "foo.bar", conf.Config.Domain)
+
+		_, err = cs.GetStakeholder("foo.bar", "foo.bar")
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), "double-call")
+	})
+
+	t.Run("failure - nil pointer", func(t *testing.T) {
+		cs := NewService(&mockconfig.MockConfigService{
+			GetStakeholderFunc: func(u string, d string) (*models.StakeholderFileData, error) {
+				return &models.StakeholderFileData{Config: nil}, nil
+			}})
+
+		_, err := cs.GetStakeholder("foo.bar", "foo.bar")
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), "nil")
+	})
+}


### PR DESCRIPTION
Wraps a config service to cache config requests in memory to avoid repeated fetches.

Part of #25 

TODO:
[ ] Synchronize map read/writes (the entire check-cache/fetch/validate/update-cache operation does not need to be atomic, but each read/write does)
[ ] Take care of the code duplication linter complaint (some refactoring)