### PR TITLE
feat: DID Resolution Result

### DIFF
--- a/pkg/restapi/didmethod/operation/operations.go
+++ b/pkg/restapi/didmethod/operation/operations.go
@@ -21,6 +21,7 @@ import (
 	didclient "github.com/trustbloc/trustbloc-did-method/pkg/did"
 	"github.com/trustbloc/trustbloc-did-method/pkg/internal/common/support"
 	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
 )
 
 const (
@@ -172,7 +173,7 @@ func (o *Operation) resolveDIDHandler(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	bytes, err := didDoc.JSONBytes()
+	bytes, err := models.MakeDIDResolutionResult(didDoc)
 	if err != nil {
 		o.writeErrorResponse(rw, http.StatusInternalServerError,
 			fmt.Sprintf("failed to marshal did doc: %s", err.Error()))

--- a/pkg/vdri/trustbloc/models/didresolutionresult.go
+++ b/pkg/vdri/trustbloc/models/didresolutionresult.go
@@ -1,0 +1,43 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+)
+
+const (
+	didResolutionResultNamespace = "https://www.w3.org/ns/did-resolution/v1"
+)
+
+// DIDResolutionResult holds the result of a DID resolution operation
+type DIDResolutionResult struct {
+	Context        string          `json:"@context"`
+	DIDDocument    json.RawMessage `json:"didDocument"`
+	MethodMetadata MethodMetaData  `json:"methodMetadata"`
+}
+
+// MethodMetaData dummy object
+type MethodMetaData struct{}
+
+// MakeDIDResolutionResult constructs, marshals, and returns a DID resolution result containing only a DID document
+func MakeDIDResolutionResult(doc *did.Doc) ([]byte, error) {
+	docBytes, err := doc.JSONBytes()
+	if err != nil {
+		return nil, fmt.Errorf("marshalling did doc: %w", err)
+	}
+
+	drr := &DIDResolutionResult{
+		Context:     didResolutionResultNamespace,
+		DIDDocument: docBytes,
+	}
+
+	return json.Marshal(drr)
+}

--- a/pkg/vdri/trustbloc/models/didresolutionresult_test.go
+++ b/pkg/vdri/trustbloc/models/didresolutionresult_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	mockdiddoc "github.com/hyperledger/aries-framework-go/pkg/mock/diddoc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeDIDResolutionResult(t *testing.T) {
+	mockdoc := mockdiddoc.GetMockDIDDoc()
+
+	resultBytes, err := MakeDIDResolutionResult(mockdoc)
+	require.NoError(t, err)
+
+	var result DIDResolutionResult
+	err = json.Unmarshal(resultBytes, &result)
+	require.NoError(t, err)
+
+	docBytes, err := mockdoc.JSONBytes()
+	require.NoError(t, err)
+
+	require.True(t, bytes.Equal(docBytes, result.DIDDocument))
+}


### PR DESCRIPTION
Wrap the returned DID doc of the didmethod REST API resolve in
a (minimal) DID Resolution Result object.

See https://w3c-ccg.github.io/did-resolution/#did-resolution-result

Part of #109

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>