### PR TITLE
 chore: update aries-framework-go: Introduce new Store wrapper

### DIFF
--- a/cmd/did-method-cli/go.mod
+++ b/cmd/did-method-cli/go.mod
@@ -7,7 +7,7 @@ module github.com/trustbloc/trustbloc-did-method/cmd/did-method-cli
 replace github.com/trustbloc/trustbloc-did-method => ../..
 
 require (
-	github.com/hyperledger/aries-framework-go v0.1.4-0.20200827142339-1873cf75190d
+	github.com/hyperledger/aries-framework-go v0.1.4-0.20200828174637-2bb12069b568
 	github.com/spf13/cobra v1.0.0
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693
 	github.com/stretchr/testify v1.6.1

--- a/cmd/did-method-cli/go.sum
+++ b/cmd/did-method-cli/go.sum
@@ -112,6 +112,8 @@ github.com/hyperledger/aries-framework-go v0.1.4-0.20200822070826-7f17683c8023 h
 github.com/hyperledger/aries-framework-go v0.1.4-0.20200822070826-7f17683c8023/go.mod h1:mzdpIGEYiXCkicIrDmrMDuLx3AJPSlvIaJMrzJNFNdI=
 github.com/hyperledger/aries-framework-go v0.1.4-0.20200827142339-1873cf75190d h1:v7gIkePnI1adinCgIUnaeYPMHW672FNZmlZfC5hm4nc=
 github.com/hyperledger/aries-framework-go v0.1.4-0.20200827142339-1873cf75190d/go.mod h1:mzdpIGEYiXCkicIrDmrMDuLx3AJPSlvIaJMrzJNFNdI=
+github.com/hyperledger/aries-framework-go v0.1.4-0.20200828174637-2bb12069b568 h1:UzdQWrKpuyL2LZvtdc4sIKEAXjvEzRKCwPPRycw0sOs=
+github.com/hyperledger/aries-framework-go v0.1.4-0.20200828174637-2bb12069b568/go.mod h1:mzdpIGEYiXCkicIrDmrMDuLx3AJPSlvIaJMrzJNFNdI=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/cmd/did-method-rest/go.sum
+++ b/cmd/did-method-rest/go.sum
@@ -124,6 +124,8 @@ github.com/hyperledger/aries-framework-go v0.1.4-0.20200822070826-7f17683c8023 h
 github.com/hyperledger/aries-framework-go v0.1.4-0.20200822070826-7f17683c8023/go.mod h1:mzdpIGEYiXCkicIrDmrMDuLx3AJPSlvIaJMrzJNFNdI=
 github.com/hyperledger/aries-framework-go v0.1.4-0.20200827142339-1873cf75190d h1:v7gIkePnI1adinCgIUnaeYPMHW672FNZmlZfC5hm4nc=
 github.com/hyperledger/aries-framework-go v0.1.4-0.20200827142339-1873cf75190d/go.mod h1:mzdpIGEYiXCkicIrDmrMDuLx3AJPSlvIaJMrzJNFNdI=
+github.com/hyperledger/aries-framework-go v0.1.4-0.20200828174637-2bb12069b568 h1:UzdQWrKpuyL2LZvtdc4sIKEAXjvEzRKCwPPRycw0sOs=
+github.com/hyperledger/aries-framework-go v0.1.4-0.20200828174637-2bb12069b568/go.mod h1:mzdpIGEYiXCkicIrDmrMDuLx3AJPSlvIaJMrzJNFNdI=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833
 	github.com/btcsuite/btcutil v1.0.1
 	github.com/gorilla/mux v1.7.4
-	github.com/hyperledger/aries-framework-go v0.1.4-0.20200827142339-1873cf75190d
+	github.com/hyperledger/aries-framework-go v0.1.4-0.20200828174637-2bb12069b568
 	github.com/sirupsen/logrus v1.4.2
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/aries-framework-go v0.1.4-0.20200827142339-1873cf75190d h1:v7gIkePnI1adinCgIUnaeYPMHW672FNZmlZfC5hm4nc=
-github.com/hyperledger/aries-framework-go v0.1.4-0.20200827142339-1873cf75190d/go.mod h1:mzdpIGEYiXCkicIrDmrMDuLx3AJPSlvIaJMrzJNFNdI=
+github.com/hyperledger/aries-framework-go v0.1.4-0.20200828174637-2bb12069b568 h1:UzdQWrKpuyL2LZvtdc4sIKEAXjvEzRKCwPPRycw0sOs=
+github.com/hyperledger/aries-framework-go v0.1.4-0.20200828174637-2bb12069b568/go.mod h1:mzdpIGEYiXCkicIrDmrMDuLx3AJPSlvIaJMrzJNFNdI=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cucumber/godog v0.9.0
 	github.com/fsouza/go-dockerclient v1.6.0
 	github.com/google/uuid v1.1.1
-	github.com/hyperledger/aries-framework-go v0.1.4-0.20200827142339-1873cf75190d
+	github.com/hyperledger/aries-framework-go v0.1.4-0.20200828174637-2bb12069b568
 	github.com/sirupsen/logrus v1.4.2
 	github.com/tidwall/gjson v1.6.0
 	github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -174,8 +174,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/aries-framework-go v0.1.4-0.20200827142339-1873cf75190d h1:v7gIkePnI1adinCgIUnaeYPMHW672FNZmlZfC5hm4nc=
-github.com/hyperledger/aries-framework-go v0.1.4-0.20200827142339-1873cf75190d/go.mod h1:mzdpIGEYiXCkicIrDmrMDuLx3AJPSlvIaJMrzJNFNdI=
+github.com/hyperledger/aries-framework-go v0.1.4-0.20200828174637-2bb12069b568 h1:UzdQWrKpuyL2LZvtdc4sIKEAXjvEzRKCwPPRycw0sOs=
+github.com/hyperledger/aries-framework-go v0.1.4-0.20200828174637-2bb12069b568/go.mod h1:mzdpIGEYiXCkicIrDmrMDuLx3AJPSlvIaJMrzJNFNdI=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=


### PR DESCRIPTION
     Revert Store to Base58 encoding of KID string and
     And added store wrapper to maintain Base64URL encoding for
     the user of the store like KMS and Packer service.

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>