### PR TITLE
feat: validating consortium update service

### DIFF
--- a/cmd/did-method-rest/go.sum
+++ b/cmd/did-method-rest/go.sum
@@ -1233,6 +1233,7 @@ gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3M
 gopkg.in/ory-am/dockertest.v3 v3.3.4/go.mod h1:s9mmoLkaGeAh97qygnNj4xWkiN7e1SKekYC6CovU+ek=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.3.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/go.sum
+++ b/go.sum
@@ -673,6 +673,7 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/pkg/vdri/trustbloc/config/signatureconfig/helpers.go
+++ b/pkg/vdri/trustbloc/config/signatureconfig/helpers.go
@@ -1,0 +1,65 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package signatureconfig
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/sirupsen/logrus"
+	"github.com/square/go-jose/v3"
+
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+// VerifyConsortiumSignatures verifies signatures on a consortium file, against stakeholder keys of a consortium config
+func VerifyConsortiumSignatures(signedData *models.ConsortiumFileData, signerConsortium *models.Consortium) error {
+	n := signerConsortium.Policy.NumQueries
+	if n == 0 || n > len(signerConsortium.Members) {
+		n = len(signerConsortium.Members)
+	}
+
+	perm := rand.Perm(len(signerConsortium.Members))
+	verifiedCount := 0
+	verificationErrors := ""
+
+	for i := 0; i < len(signerConsortium.Members); i++ {
+		keyData := signerConsortium.Members[perm[i]].PublicKey.JWK
+		key := jose.JSONWebKey{}
+
+		err := key.UnmarshalJSON(keyData)
+		if err != nil {
+			msg := "bad key for stakeholder: " + signerConsortium.Members[perm[i]].Domain
+			logrus.Warn(msg)
+			verificationErrors += msg + ", "
+
+			continue
+		}
+
+		_, _, _, err = signedData.JWS.VerifyMulti(key)
+		if err != nil {
+			msg := "key fails to verify for stakeholder: " + signerConsortium.Members[perm[i]].Domain
+			logrus.Warn(msg)
+			verificationErrors += msg + ", "
+
+			continue
+		}
+
+		verifiedCount++
+
+		if verifiedCount == n {
+			break
+		}
+	}
+
+	if verifiedCount < n {
+		return fmt.Errorf(
+			"insufficient stakeholder endorsement of consortium config file. errors are: [%s]",
+			verificationErrors)
+	}
+
+	return nil
+}

--- a/pkg/vdri/trustbloc/config/signatureconfig/service.go
+++ b/pkg/vdri/trustbloc/config/signatureconfig/service.go
@@ -7,10 +7,6 @@ package signatureconfig
 
 import (
 	"fmt"
-	"math/rand"
-
-	log "github.com/sirupsen/logrus"
-	"github.com/square/go-jose/v3"
 
 	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
 )
@@ -44,48 +40,9 @@ func (cs *ConfigService) GetConsortium(url, domain string) (*models.ConsortiumFi
 		return nil, fmt.Errorf("consortium is nil")
 	}
 
-	n := consortium.Policy.NumQueries
-	if n == 0 || n > len(consortium.Members) {
-		n = len(consortium.Members)
-	}
-
-	perm := rand.Perm(len(consortium.Members))
-	verifiedCount := 0
-	verificationErrors := ""
-
-	for i := 0; i < len(consortium.Members); i++ {
-		keyData := consortium.Members[perm[i]].PublicKey.JWK
-		key := jose.JSONWebKey{}
-
-		err := key.UnmarshalJSON(keyData)
-		if err != nil {
-			msg := "bad key for stakeholder: " + consortium.Members[perm[i]].Domain
-			log.Warn(msg)
-			verificationErrors += msg + ", "
-
-			continue
-		}
-
-		_, _, _, err = consortiumData.JWS.VerifyMulti(key)
-		if err != nil {
-			msg := "key fails to verify for stakeholder: " + consortium.Members[perm[i]].Domain
-			log.Warn(msg)
-			verificationErrors += msg + ", "
-
-			continue
-		}
-
-		verifiedCount++
-
-		if verifiedCount == n {
-			break
-		}
-	}
-
-	if verifiedCount < n {
-		return nil, fmt.Errorf(
-			"insufficient stakeholder endorsement of consortium config file. errors are: [%s]",
-			verificationErrors)
+	err = VerifyConsortiumSignatures(consortiumData, consortium)
+	if err != nil {
+		return nil, err
 	}
 
 	return consortiumData, nil

--- a/pkg/vdri/trustbloc/config/updatevalidationconfig/service.go
+++ b/pkg/vdri/trustbloc/config/updatevalidationconfig/service.go
@@ -1,0 +1,99 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package updatevalidationconfig
+
+import (
+	"fmt"
+
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/config/signatureconfig"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+type config interface {
+	GetConsortium(string, string) (*models.ConsortiumFileData, error)
+	GetStakeholder(string, string) (*models.StakeholderFileData, error)
+}
+
+// ConfigService fetches consortium and stakeholder configs
+// Caches the current consortium config, and when updating, uses signature validation to verify that the updated
+// consortium config is a valid update to the current one.
+type ConfigService struct {
+	config    config
+	consortia map[stringPair]*models.ConsortiumFileData
+}
+
+// NewService create new ConfigService
+func NewService(config config) *ConfigService {
+	configService := &ConfigService{config: config}
+
+	configService.consortia = map[stringPair]*models.ConsortiumFileData{}
+
+	return configService
+}
+
+// GetConsortium fetches and parses the consortium file at the given domain, validating it against a cached version
+// of the file. Validation passes if the retrieved file is either:
+//     a) the same as the cached file
+//  or b) a valid successor, endorsed by the cached file
+func (cs *ConfigService) GetConsortium(url, domain string) (*models.ConsortiumFileData, error) {
+	key := stringPair{domain: domain, url: url}
+
+	cachedConsortium, ok := cs.consortia[key]
+	if !ok || cachedConsortium == nil {
+		return nil, fmt.Errorf("cached config missing from cache")
+	}
+
+	consortium := cachedConsortium.Config
+	if consortium == nil {
+		return nil, fmt.Errorf("cached consortium is nil")
+	}
+
+	// if we're here, the cached consortium has expired and we must refresh or update, and validate
+
+	consortiumData, err := cs.config.GetConsortium(url, domain)
+	if err != nil {
+		return nil, fmt.Errorf("wrapped config service: %w", err)
+	}
+
+	// if they're the same, return
+	if cachedConsortium.JWS.FullSerialize() == consortiumData.JWS.FullSerialize() {
+		return cachedConsortium, nil
+	}
+
+	// validate new fetched data against old's signatures
+	err = signatureconfig.VerifyConsortiumSignatures(consortiumData, consortium)
+	if err != nil {
+		return nil, fmt.Errorf("signature fails: %w", err)
+	}
+
+	cs.consortia[key] = consortiumData
+
+	return consortiumData, nil
+}
+
+type stringPair struct {
+	url, domain string
+}
+
+// AddGenesisFile adds a genesis file to the config.
+func (cs *ConfigService) AddGenesisFile(url, domain string, genesisFile []byte) error {
+	genesisConsortium, err := models.ParseConsortium(genesisFile)
+	if err != nil {
+		return fmt.Errorf("failed to add genesis file for url: %s, error: %w", url, err)
+	}
+
+	// TODO: error if repeat (url, domain)?
+	// TODO: error if a genesis file is added during operation, after startup is already finished?
+
+	cs.consortia[stringPair{domain: domain, url: url}] = genesisConsortium
+
+	return nil
+}
+
+// GetStakeholder returns the stakeholder config file fetched by the wrapped config service
+func (cs *ConfigService) GetStakeholder(url, domain string) (*models.StakeholderFileData, error) {
+	return cs.config.GetStakeholder(url, domain)
+}

--- a/pkg/vdri/trustbloc/config/updatevalidationconfig/service_test.go
+++ b/pkg/vdri/trustbloc/config/updatevalidationconfig/service_test.go
@@ -1,0 +1,265 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package updatevalidationconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/square/go-jose/v3"
+	"github.com/stretchr/testify/require"
+
+	mockconfig "github.com/trustbloc/trustbloc-did-method/pkg/internal/mock/config"
+	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc/models"
+)
+
+func signConsortium(consortium *models.Consortium, keys ...jose.SigningKey) (*jose.JSONWebSignature, error) {
+	signer, err := jose.NewMultiSigner(keys, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	consortiumBytes, err := json.Marshal(consortium)
+	if err != nil {
+		return nil, err
+	}
+
+	return signer.Sign(consortiumBytes)
+}
+
+func TestConfigService_AddGenesisFile(t *testing.T) {
+	rawPrivKey := []byte(`{
+  "kty": "OKP",
+  "kid": "key1",
+  "d": "CSLczqR1ly2lpyBcWne9gFKnsjaKJw0dKfoSQu7lNvg",
+  "crv": "Ed25519",
+  "x": "bWRCy8DtNhRO3HdKTFB2eEG5Ac1J00D0DQPffOwtAD0"
+}`)
+
+	key := jose.JSONWebKey{}
+	e := key.UnmarshalJSON(rawPrivKey)
+	require.NoError(t, e)
+
+	sigKey := jose.SigningKey{Key: key.Key, Algorithm: jose.EdDSA}
+
+	t.Run("success", func(t *testing.T) {
+		cs := NewService(nil)
+
+		genesis, err := signConsortium(&models.Consortium{Domain: "foo"}, sigKey)
+		require.NoError(t, err)
+
+		err = cs.AddGenesisFile("foo", "foo", []byte(genesis.FullSerialize()))
+		require.NoError(t, err)
+	})
+
+	t.Run("failure - genesis file is corrupt", func(t *testing.T) {
+		cs := NewService(nil)
+
+		err := cs.AddGenesisFile("foo", "foo", []byte("whoops}"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "genesis file for url")
+	})
+}
+
+func TestConfigService_GetConsortium(t *testing.T) {
+	rawPrivKey := []byte(`{
+  "kty": "OKP",
+  "kid": "key1",
+  "d": "CSLczqR1ly2lpyBcWne9gFKnsjaKJw0dKfoSQu7lNvg",
+  "crv": "Ed25519",
+  "x": "bWRCy8DtNhRO3HdKTFB2eEG5Ac1J00D0DQPffOwtAD0"
+}`)
+
+	key := jose.JSONWebKey{}
+	e := key.UnmarshalJSON(rawPrivKey)
+	require.NoError(t, e)
+
+	sigKey := jose.SigningKey{Key: key.Key, Algorithm: jose.EdDSA}
+
+	t.Run("success - file retrieved is same as genesis", func(t *testing.T) {
+		rawPubKey := []byte(`{
+  "kty": "OKP",
+  "kid": "key1",
+  "crv": "Ed25519",
+  "x": "bWRCy8DtNhRO3HdKTFB2eEG5Ac1J00D0DQPffOwtAD0"
+}`)
+
+		config := models.Consortium{
+			Members: []*models.StakeholderListElement{
+				{PublicKey: models.PublicKey{JWK: json.RawMessage(rawPubKey)}},
+			},
+			Domain: "foo",
+		}
+
+		sig, err := signConsortium(&config, sigKey)
+		require.NoError(t, err)
+
+		cs := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(u string, d string) (*models.ConsortiumFileData, error) {
+				return &models.ConsortiumFileData{
+					Config: &config,
+					JWS:    sig,
+				}, nil
+			},
+		})
+
+		err = cs.AddGenesisFile("foo", "foo", []byte(sig.FullSerialize()))
+		require.NoError(t, err)
+
+		res, err := cs.GetConsortium("foo", "foo")
+		require.NoError(t, err)
+		require.Equal(t, "foo", res.Config.Domain)
+	})
+
+	t.Run("success - genesis file endorses derived file", func(t *testing.T) {
+		rawPubKey := []byte(`{
+  "kty": "OKP",
+  "kid": "key1",
+  "crv": "Ed25519",
+  "x": "bWRCy8DtNhRO3HdKTFB2eEG5Ac1J00D0DQPffOwtAD0"
+}`)
+		config := models.Consortium{
+			Members: []*models.StakeholderListElement{
+				{PublicKey: models.PublicKey{JWK: json.RawMessage(rawPubKey)}},
+			},
+		}
+
+		sig, err := signConsortium(&config, sigKey)
+		require.NoError(t, err)
+
+		cs := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(u string, d string) (*models.ConsortiumFileData, error) {
+				return &models.ConsortiumFileData{
+					Config: &config,
+					JWS:    sig,
+				}, nil
+			},
+		})
+
+		genesis := &models.Consortium{
+			Members: []*models.StakeholderListElement{
+				{PublicKey: models.PublicKey{JWK: json.RawMessage(rawPubKey)}},
+			},
+			Domain: "beep",
+		}
+
+		sig2, err := signConsortium(genesis, sigKey)
+		require.NoError(t, err)
+
+		err = cs.AddGenesisFile("foo", "foo", []byte(sig2.FullSerialize()))
+		require.NoError(t, err)
+
+		_, err = cs.GetConsortium("foo", "foo")
+		require.NoError(t, err)
+	})
+
+	t.Run("failure - no genesis saved", func(t *testing.T) {
+		cs := NewService(nil)
+
+		_, err := cs.GetConsortium("foo", "foo")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing from cache")
+	})
+
+	t.Run("failure - nil genesis saved", func(t *testing.T) {
+		cs := NewService(nil)
+
+		cs.consortia[stringPair{"foo", "foo"}] = nil
+
+		_, err := cs.GetConsortium("foo", "foo")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing from cache")
+	})
+
+	t.Run("failure - genesis has nil consortium", func(t *testing.T) {
+		cs := NewService(nil)
+
+		cs.consortia[stringPair{"foo", "foo"}] = &models.ConsortiumFileData{}
+
+		_, err := cs.GetConsortium("foo", "foo")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "consortium is nil")
+	})
+
+	t.Run("failure - failed to fetch config", func(t *testing.T) {
+		cs := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(url string, domain string) (*models.ConsortiumFileData, error) {
+				return nil, fmt.Errorf("config error")
+			},
+		})
+
+		cs.consortia[stringPair{"foo", "foo"}] = &models.ConsortiumFileData{
+			Config: &models.Consortium{},
+		}
+
+		_, err := cs.GetConsortium("foo", "foo")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "config error")
+	})
+
+	t.Run("failure - signature failed to verify", func(t *testing.T) {
+		rawPubKey := []byte(`[]`)
+		config := models.Consortium{
+			Members: []*models.StakeholderListElement{
+				{PublicKey: models.PublicKey{JWK: json.RawMessage(rawPubKey)}},
+			},
+		}
+
+		sig, err := signConsortium(&config, sigKey)
+		require.NoError(t, err)
+
+		cs := NewService(&mockconfig.MockConfigService{
+			GetConsortiumFunc: func(u string, d string) (*models.ConsortiumFileData, error) {
+				return &models.ConsortiumFileData{
+					Config: &config,
+					JWS:    sig,
+				}, nil
+			},
+		})
+
+		genesis := &models.Consortium{
+			Members: []*models.StakeholderListElement{
+				{PublicKey: models.PublicKey{JWK: json.RawMessage(rawPubKey)}},
+			},
+			Domain: "beep",
+		}
+
+		sig2, err := signConsortium(genesis, sigKey)
+		require.NoError(t, err)
+
+		err = cs.AddGenesisFile("foo", "foo", []byte(sig2.FullSerialize()))
+		require.NoError(t, err)
+
+		_, err = cs.GetConsortium("foo", "foo")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature fails")
+	})
+}
+
+func TestConfigService_GetStakeholder(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		cs := NewService(&mockconfig.MockConfigService{
+			GetStakeholderFunc: func(u string, d string) (*models.StakeholderFileData, error) {
+				return &models.StakeholderFileData{Config: &models.Stakeholder{Domain: "foo.bar"}}, nil
+			}})
+
+		sh, err := cs.GetStakeholder("foo", "foo")
+		require.NoError(t, err)
+		require.Equal(t, "foo.bar", sh.Config.Domain)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		cs := NewService(&mockconfig.MockConfigService{
+			GetStakeholderFunc: func(u string, d string) (*models.StakeholderFileData, error) {
+				return nil, fmt.Errorf("error error")
+			}})
+
+		_, err := cs.GetStakeholder("foo", "foo")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error error")
+	})
+}

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1244,6 +1244,7 @@ gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3M
 gopkg.in/ory-am/dockertest.v3 v3.3.4/go.mod h1:s9mmoLkaGeAh97qygnNj4xWkiN7e1SKekYC6CovU+ek=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.3.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=


### PR DESCRIPTION
service that validates each consortium it pulls, against a cached
prior version, to verify signature endorsement. Requires an initial
genesis file to be stored in the service for each consortium.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>