### PR TITLE
feat: consortium config update bdd test 

### DIFF
--- a/cmd/did-method-cli/createconfigcmd/createconfig.go
+++ b/cmd/did-method-cli/createconfigcmd/createconfig.go
@@ -174,12 +174,7 @@ func getParameters(cmd *cobra.Command) (*parameters, error) {
 }
 
 func writeFiles(outputDirectory string, filesData, didConfData map[string][]byte) error {
-	err := os.RemoveAll(outputDirectory)
-	if err != nil {
-		return fmt.Errorf("remove outputDirectory: %w", err)
-	}
-
-	err = configcommon.WriteConfig(outputDirectory, filesData)
+	err := configcommon.WriteConfig(outputDirectory, filesData)
 	if err != nil {
 		return err
 	}

--- a/cmd/did-method-cli/updateconfigcmd/updateconfig.go
+++ b/cmd/did-method-cli/updateconfigcmd/updateconfig.go
@@ -60,7 +60,7 @@ func createUpdateConfigCmd() *cobra.Command {
 				return err
 			}
 
-			hash, err := moveToHistory(parameters.prevConfig, path.Join(parameters.outputDirectory, "history"))
+			hash, err := moveToHistory(parameters.prevConfig, path.Join(parameters.outputDirectory, "did-trustbloc", "history"))
 			if err != nil {
 				return err
 			}

--- a/cmd/did-method-rest/startcmd/start_test.go
+++ b/cmd/did-method-rest/startcmd/start_test.go
@@ -6,7 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 package startcmd
 
 import (
+	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -16,10 +18,16 @@ import (
 
 const flag = "--"
 
-type mockServer struct{}
+type mockServer struct {
+	serveHandler func(string, http.Handler) error
+}
 
 func (s *mockServer) ListenAndServe(host string, handler http.Handler) error {
-	return nil
+	if s.serveHandler == nil {
+		return nil
+	}
+
+	return s.serveHandler(host, handler)
 }
 
 func TestListenAndServe(t *testing.T) {
@@ -69,6 +77,216 @@ func TestStartCmdWithInvalidEnableSignaturesArg(t *testing.T) {
 
 	err := startCmd.Execute()
 	require.Error(t, err)
+}
+
+func TestStartCmdWithGenesisFile(t *testing.T) {
+	const (
+		// nolint: lll
+		genesisFile = `{
+"payload":"eyJkb21haW4iOiJ0ZXN0bmV0LnRydXN0YmxvYy5sb2NhbCIsInBvbGljeSI6eyJjYWNoZSI6eyJtYXhBZ2UiOjI0MTkyMDB9LCJudW1RdWVyaWVzIjoyfSwibWVtYmVycyI6W3siZG9tYWluIjoic3Rha2Vob2xkZXIub25lIiwicHVibGljS2V5Ijp7ImlkIjoiI2tleTEiLCJqd2siOnsia3R5IjoiT0tQIiwia2lkIjoia2V5MSIsImNydiI6IkVkMjU1MTkiLCJ4IjoiYldSQ3k4RHROaFJPM0hkS1RGQjJlRUc1QWMxSjAwRDBEUVBmZk93dEFEMCJ9fX1dLCJwcmV2aW91cyI6ImZvb2JhciJ9",
+"protected":"eyJhbGciOiJFZERTQSJ9",
+"signature":"r9t2zfeMht4VwbmTtY22hhCykWgR4qkkM1RZYPV6BFVKiLZBpaHVqhnUQ8X1nXzSSMAqTLaKNM9Q1C5ayBxrBw"
+}
+`
+
+		badFile = `lorem ipsum dolor sit amet`
+
+		badPayload = `{
+"payload":"aaaa",
+"protected":"eyJhbGciOiJFZERTQSJ9",
+"signature":"r9t2zfeMht4VwbmTtY22hhCykWgR4qkkM1RZYPV6BFVKiLZBpaHVqhnUQ8X1nXzSSMAqTLaKNM9Q1C5ayBxrBw"
+}
+`
+		invalidConfig = `{
+"payload":"eyJjIjp7fX0",
+"protected":"eyJhbGciOiJFZERTQSJ9",
+"signature":"r9t2zfeMht4VwbmTtY22hhCykWgR4qkkM1RZYPV6BFVKiLZBpaHVqhnUQ8X1nXzSSMAqTLaKNM9Q1C5ayBxrBw"
+}
+`
+	)
+
+	t.Run("success", func(t *testing.T) {
+		file, err := ioutil.TempFile("", "*.json")
+		require.NoError(t, err)
+
+		_, err = file.WriteString(genesisFile)
+		require.NoError(t, err)
+
+		defer func() { require.NoError(t, os.Remove(file.Name())) }()
+
+		args := getValidArgs()
+		args = append(args, flag+genesisFileFlagName, file.Name())
+
+		startCmd := GetStartCmd(&mockServer{})
+		startCmd.SetArgs(args)
+
+		err = startCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	t.Run("success: multiple genesis files", func(t *testing.T) {
+		file, err := ioutil.TempFile("", "*.json")
+		require.NoError(t, err)
+
+		_, err = file.WriteString(genesisFile)
+		require.NoError(t, err)
+
+		defer func() { require.NoError(t, os.Remove(file.Name())) }()
+
+		args := getValidArgs()
+		args = append(args,
+			flag+genesisFileFlagName, file.Name(),
+			flag+genesisFileFlagName, file.Name(),
+		)
+
+		startCmd := GetStartCmd(&mockServer{})
+		startCmd.SetArgs(args)
+
+		err = startCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	t.Run("failure reading genesis file", func(t *testing.T) {
+		args := getValidArgs()
+		args = append(args, flag+genesisFileFlagName, "./$$$$$$$$$$badfilename.no")
+
+		startCmd := GetStartCmd(&mockServer{})
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reading genesis file")
+	})
+
+	t.Run("failure parsing genesis file", func(t *testing.T) {
+		file, err := ioutil.TempFile("", "*.json")
+		require.NoError(t, err)
+
+		_, err = file.WriteString(badFile)
+		require.NoError(t, err)
+
+		defer func() { require.NoError(t, os.Remove(file.Name())) }()
+
+		args := getValidArgs()
+		args = append(args, flag+genesisFileFlagName, file.Name())
+
+		startCmd := GetStartCmd(&mockServer{})
+		startCmd.SetArgs(args)
+
+		err = startCmd.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parsing genesis file")
+	})
+
+	t.Run("failure parsing genesis config", func(t *testing.T) {
+		file, err := ioutil.TempFile("", "*.json")
+		require.NoError(t, err)
+
+		_, err = file.WriteString(badPayload)
+		require.NoError(t, err)
+
+		defer func() { require.NoError(t, os.Remove(file.Name())) }()
+
+		args := getValidArgs()
+		args = append(args, flag+genesisFileFlagName, file.Name())
+
+		startCmd := GetStartCmd(&mockServer{})
+		startCmd.SetArgs(args)
+
+		err = startCmd.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid character")
+	})
+
+	t.Run("failure: genesis file is invalid config", func(t *testing.T) {
+		file, err := ioutil.TempFile("", "*.json")
+		require.NoError(t, err)
+
+		_, err = file.WriteString(invalidConfig)
+		require.NoError(t, err)
+
+		defer func() { require.NoError(t, os.Remove(file.Name())) }()
+
+		args := getValidArgs()
+		args = append(args, flag+genesisFileFlagName, file.Name())
+
+		var mockHandler http.Handler
+
+		server := &mockServer{
+			serveHandler: func(host string, handler http.Handler) error {
+				mockHandler = handler
+				return nil
+			},
+		}
+
+		startCmd := GetStartCmd(server)
+		startCmd.SetArgs(args)
+
+		err = startCmd.Execute()
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+
+		mockHandler.ServeHTTP(rw, httptest.NewRequest("", "/resolveDID?did=did:trustbloc:testnet.trustbloc.local:abc", nil))
+
+		res := rw.Result()
+
+		require.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+		body, err := ioutil.ReadAll(res.Body)
+		require.NoError(t, err)
+
+		require.NoError(t, res.Body.Close())
+
+		require.Contains(t, string(body), "cached config missing")
+	})
+
+	t.Run("success: load genesis file and (fail to) resolve a DID", func(t *testing.T) {
+		file, err := ioutil.TempFile("", "*.json")
+		require.NoError(t, err)
+
+		_, err = file.WriteString(genesisFile)
+		require.NoError(t, err)
+
+		defer func() { require.NoError(t, os.Remove(file.Name())) }()
+
+		var args []string
+		args = append(args, hostURLArg()...)
+		args = append(args,
+			flag+domainFlagName, "consortium.net",
+			flag+genesisFileFlagName, file.Name(),
+		)
+
+		var mockHandler http.Handler
+
+		server := &mockServer{
+			serveHandler: func(host string, handler http.Handler) error {
+				mockHandler = handler
+				return nil
+			},
+		}
+
+		startCmd := GetStartCmd(server)
+		startCmd.SetArgs(args)
+
+		err = startCmd.Execute()
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+
+		mockHandler.ServeHTTP(rw, httptest.NewRequest("", "/resolveDID?did=did:trustbloc:testnet.trustbloc.local:abc", nil))
+
+		res := rw.Result()
+
+		require.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+		body, err := ioutil.ReadAll(res.Body)
+		require.NoError(t, err)
+
+		require.NoError(t, res.Body.Close())
+
+		require.Contains(t, string(body), "failed to resolve did")
+	})
 }
 
 func TestStartCmdValidArgsEnvVar(t *testing.T) {

--- a/pkg/vdri/trustbloc/config/updatevalidationconfig/service.go
+++ b/pkg/vdri/trustbloc/config/updatevalidationconfig/service.go
@@ -67,7 +67,7 @@ func (cs *ConfigService) GetConsortium(url, domain string) (*models.ConsortiumFi
 	// validate new fetched data against old's signatures
 	err = signatureconfig.VerifyConsortiumSignatures(consortiumData, consortium)
 	if err != nil {
-		return nil, fmt.Errorf("signature fails: %w", err)
+		return nil, fmt.Errorf("config update signature does not verify: %w", err)
 	}
 
 	cs.consortia[key] = consortiumData

--- a/pkg/vdri/trustbloc/vdri.go
+++ b/pkg/vdri/trustbloc/vdri.go
@@ -96,7 +96,8 @@ func New(opts ...Option) *VDRI {
 
 	switch {
 	case v.useUpdateValidation:
-		v.updateValidationService = updatevalidationconfig.NewService(verifyingconfig.NewService(configService))
+		verifyingService := signatureconfig.NewService(verifyingconfig.NewService(configService))
+		v.updateValidationService = updatevalidationconfig.NewService(verifyingService)
 		v.configService = memorycacheconfig.NewService(v.updateValidationService)
 	case v.enableSignatureVerification:
 		verifyingService := signatureconfig.NewService(verifyingconfig.NewService(configService))

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -55,12 +55,17 @@ func runBDDTests(tags, format string) int {
 	return godog.RunWithOptions("godogs", func(s *godog.Suite) {
 		var composition []*dockerutil.Composition
 		var composeFiles = []string{"./fixtures/did-method-rest", "./fixtures/universalresolver",
-			"./fixtures/sidetree-mock",
+			"./fixtures/sidetree-mock", "./fixtures/discovery-server", "./fixtures/stakeholder-server",
 			"./fixtures/universal-registrar"}
-		var discoveryServers = []string{"./fixtures/discovery-server", "./fixtures/stakeholder-server"}
 
 		s.BeforeSuite(func() {
 			if os.Getenv("DISABLE_COMPOSITION") != "true" { // nolint: nestif
+				// create dummy config files (that will be overwritten in tests)
+				_, err := execCMD("./generate_stub_config.sh")
+				if err != nil {
+					panic(err.Error())
+				}
+
 				// Need a unique name, but docker does not allow '-' in names
 				composeProjectName := strings.ReplaceAll(generateUUID(), "-", "")
 
@@ -72,7 +77,7 @@ func runBDDTests(tags, format string) int {
 					composition = append(composition, newComposition)
 				}
 				fmt.Println("docker-compose up ... waiting for containers to start ...")
-				testSleep := 20
+				testSleep := 15
 				if os.Getenv("TEST_SLEEP") != "" {
 					var e error
 
@@ -82,23 +87,6 @@ func runBDDTests(tags, format string) int {
 					}
 				}
 				fmt.Printf("*** testSleep=%d \n", testSleep)
-				time.Sleep(time.Second * time.Duration(testSleep))
-
-				// create config files
-				_, err := execCMD("./generate_config.sh")
-				if err != nil {
-					panic(err.Error())
-				}
-
-				for _, v := range discoveryServers {
-					newComposition, err := dockerutil.NewComposition(composeProjectName, "docker-compose.yml", v)
-					if err != nil {
-						panic(fmt.Sprintf("Error composing system in BDD context: %s", err))
-					}
-					composition = append(composition, newComposition)
-				}
-
-				fmt.Printf("*** testSleep=%d", testSleep)
 				time.Sleep(time.Second * time.Duration(testSleep))
 			}
 		})

--- a/test/bdd/features/did_method_cli.feature
+++ b/test/bdd/features/did_method_cli.feature
@@ -10,6 +10,7 @@ Feature: Using DID method CLI
 
   @cli_did
   Scenario: test create and update did doc using cli
+    Given Consortium config is generated with config file "./fixtures/wellknown/config.json"
     When TrustBloc DID is created through cli using domain "", direct url "https://localhost:48326/sidetree/0.0.1"
     Then check cli created valid DID
     When TrustBloc DID is updated through cli using domain "testnet.trustbloc.local", direct url ""

--- a/test/bdd/features/did_method_e2e.feature
+++ b/test/bdd/features/did_method_e2e.feature
@@ -10,8 +10,10 @@ Feature: Using DID method REST API
 
   @e2e_universalresolver
   Scenario Outline: create trustbloc did and resolve through universalresolver
-    Given TrustBloc DID is created through registrar "http://localhost:9080/1.0/register?driverId=driver-did-method-rest" with key type "<keyType>" with signature suite "<signatureSuite>"
-    Then Resolve created DID through resolver URL "http://localhost:8080/1.0/identifiers" and validate key type "<keyType>", signature suite "<signatureSuite>"
+    Given Consortium config is generated with config file "./fixtures/wellknown/config.json"
+    Then TrustBloc DID is created through registrar "http://localhost:9080/1.0/register?driverId=driver-did-method-rest" with key type "<keyType>" with signature suite "<signatureSuite>"
+    Then Bloc VDRI is initialized with resolver URL "http://localhost:8080/1.0/identifiers"
+    Then Resolve created DID and validate key type "<keyType>", signature suite "<signatureSuite>"
     Examples:
       | keyType  |  signatureSuite             |
       | Ed25519  |  Ed25519VerificationKey2018 |
@@ -19,8 +21,36 @@ Feature: Using DID method REST API
 
   @e2e_sidetree
   Scenario Outline: create trustbloc did and resolve through sidetree-mock
-    Given TrustBloc DID is created through registrar "http://localhost:9080/1.0/register?driverId=driver-did-method-rest" with key type "<keyType>" with signature suite "<signatureSuite>"
-    Then Resolve created DID through resolver URL "https://localhost:48326/sidetree/0.0.1/identifiers" and validate key type "<keyType>", signature suite "<signatureSuite>"
+    Given Consortium config is generated with config file "./fixtures/wellknown/config.json"
+    Then TrustBloc DID is created through registrar "http://localhost:9080/1.0/register?driverId=driver-did-method-rest" with key type "<keyType>" with signature suite "<signatureSuite>"
+    Then Bloc VDRI is initialized with resolver URL "https://localhost:48326/sidetree/0.0.1/identifiers"
+    Then Resolve created DID and validate key type "<keyType>", signature suite "<signatureSuite>"
+    Examples:
+      | keyType  |  signatureSuite             |
+      | Ed25519  |  JwsVerificationKey2020     |
+      | P256     |  JwsVerificationKey2020     |
+      | Ed25519  |  Ed25519VerificationKey2018 |
+
+  @e2e_update_config
+  Scenario Outline: create trustbloc did and resolve after updating consortium config
+    Given Consortium config is generated with config file "./fixtures/wellknown/stale_config.json"
+    Then TrustBloc DID is created through registrar "http://localhost:9080/1.0/register?driverId=driver-did-method-rest" with key type "<keyType>" with signature suite "<signatureSuite>"
+    Then Bloc VDRI is initialized with genesis file "./fixtures/wellknown/jws/did-trustbloc/testnet.trustbloc.local.json"
+    Then Consortium config is updated with config file "./fixtures/wellknown/update_config.json"
+    Then Resolve created DID and validate key type "<keyType>", signature suite "<signatureSuite>"
+    Examples:
+      | keyType  |  signatureSuite             |
+      | Ed25519  |  JwsVerificationKey2020     |
+      | P256     |  JwsVerificationKey2020     |
+      | Ed25519  |  Ed25519VerificationKey2018 |
+
+  @e2e_bad_update_config
+  Scenario Outline: fail to resolve did after a consortium config update isn't signed by stakeholders
+    Given Consortium config is generated with config file "./fixtures/wellknown/stale_config.json"
+    Then TrustBloc DID is created through registrar "http://localhost:9080/1.0/register?driverId=driver-did-method-rest" with key type "<keyType>" with signature suite "<signatureSuite>"
+    Then Bloc VDRI is initialized with genesis file "./fixtures/wellknown/jws/did-trustbloc/testnet.trustbloc.local.json"
+    Then Consortium config is updated with config file "./fixtures/wellknown/bad_update_config.json"
+    Then DID resolution fails, containing error "config update signature does not verify"
     Examples:
       | keyType  |  signatureSuite             |
       | Ed25519  |  JwsVerificationKey2020     |

--- a/test/bdd/fixtures/discovery-server/docker-compose.yml
+++ b/test/bdd/fixtures/discovery-server/docker-compose.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3'
+version: '3.2'
 
 services:
 
@@ -21,7 +21,13 @@ services:
     ports:
       - "443:443"
     volumes:
-      - ../wellknown/jws/did-trustbloc:/web/.well-known/did-trustbloc
+      - type: bind
+        source: ../wellknown/jws/did-trustbloc
+        target: /web/.well-known/did-trustbloc
+        volume:
+          nocopy: true
+        bind:
+          propagation: shared
       - ../keys/tls:/etc/tls
     networks:
       - did-method-rest_bdd_net

--- a/test/bdd/fixtures/stakeholder-server/docker-compose.yml
+++ b/test/bdd/fixtures/stakeholder-server/docker-compose.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3'
+version: '3.2'
 
 services:
 
@@ -21,8 +21,16 @@ services:
     ports:
       - "8088:8088"
     volumes:
-      - ../wellknown/jws/did-trustbloc:/web/.well-known/did-trustbloc
-      - ../wellknown/jws/stakeholder.one/did-configuration.json:/web/.well-known/did-configuration.json
+      - type: bind
+        source: ../wellknown/jws/did-trustbloc
+        target: /web/.well-known/did-trustbloc
+      - type: bind
+        source: ../wellknown/jws/stakeholder.one/did-configuration.json
+        target: /web/.well-known/did-configuration.json
+        volume:
+          nocopy: true
+        bind:
+          propagation: shared
       - ../keys/tls:/etc/tls
     networks:
       - did-method-rest_bdd_net

--- a/test/bdd/fixtures/wellknown/bad_update_config.json
+++ b/test/bdd/fixtures/wellknown/bad_update_config.json
@@ -1,0 +1,23 @@
+{
+  "consortiumData": {
+    "domain": "testnet.trustbloc.local",
+    "genesisBlock": "6e2f978e16b59df1d6a1dfbacb92e7d3eddeb8b3fd825e573138b3fd77d77264",
+    "policy": {
+      "cache": {
+        "maxAge": 1
+      },
+      "numQueries": 1,
+      "historyHash": "SHA256"
+    }
+  },
+  "membersData": [
+    {
+      "domain": "stakeholder.one:8088",
+      "policy": {"cache": {"maxAge": 604800}},
+      "endpoints": [
+        "https://localhost:48326/sidetree/0.0.1"
+      ],
+      "privateKeyJwkPath": "../../test/bdd/fixtures/wellknown/wrong_jwk.json"
+    }
+  ]
+}

--- a/test/bdd/fixtures/wellknown/stale_config.json
+++ b/test/bdd/fixtures/wellknown/stale_config.json
@@ -1,0 +1,31 @@
+{
+  "consortiumData": {
+    "domain": "testnet.trustbloc.local",
+    "genesisBlock": "6e2f978e16b59df1d6a1dfbacb92e7d3eddeb8b3fd825e573138b3fd77d77264",
+    "policy": {
+      "cache": {
+        "maxAge": 1
+      },
+      "numQueries": 2,
+      "historyHash": "SHA256"
+    }
+  },
+  "membersData": [
+    {
+      "domain": "stakeholder.one:8088",
+      "policy": {"cache": {"maxAge": 604800}},
+      "endpoints": [
+        "https://localhost:48326/sidetree/0.0.1"
+      ],
+      "privateKeyJwkPath": "../../test/bdd/fixtures/wellknown/stakeholderone_jwk.json"
+    },
+    {
+      "domain": "stakeholder.two:8089",
+      "policy": {"cache": {"maxAge": 604800}},
+      "endpoints": [
+        "https://localhost:48326/sidetree/0.0.1"
+      ],
+      "privateKeyJwkPath": "../../test/bdd/fixtures/wellknown/stakeholdertwo_jwk.json"
+    }
+  ]
+}

--- a/test/bdd/fixtures/wellknown/update_config.json
+++ b/test/bdd/fixtures/wellknown/update_config.json
@@ -1,0 +1,31 @@
+{
+  "consortiumData": {
+    "domain": "testnet.trustbloc.local",
+    "genesisBlock": "6e2f978e16b59df1d6a1dfbacb92e7d3eddeb8b3fd825e573138b3fd77d77264",
+    "policy": {
+      "cache": {
+        "maxAge": 12345678
+      },
+      "numQueries": 2,
+      "historyHash": "SHA256"
+    }
+  },
+  "membersData": [
+    {
+      "domain": "stakeholder.one:8088",
+      "policy": {"cache": {"maxAge": 604800}},
+      "endpoints": [
+        "https://localhost:48326/sidetree/0.0.1"
+      ],
+      "privateKeyJwkPath": "../../test/bdd/fixtures/wellknown/stakeholderone_jwk.json"
+    },
+    {
+      "domain": "stakeholder.two:8089",
+      "policy": {"cache": {"maxAge": 604800}},
+      "endpoints": [
+        "https://localhost:48326/sidetree/0.0.1"
+      ],
+      "privateKeyJwkPath": "../../test/bdd/fixtures/wellknown/stakeholdertwo_jwk.json"
+    }
+  ]
+}

--- a/test/bdd/fixtures/wellknown/wrong_jwk.json
+++ b/test/bdd/fixtures/wellknown/wrong_jwk.json
@@ -1,0 +1,7 @@
+{
+  "kty": "OKP",
+  "kid": "key1",
+  "d": "cg2LVQmAw30VdGITbhhhpVNPFHOAUQ9o5mL_TiL6xQ4",
+  "crv": "Ed25519",
+  "x": "4HSq8PBsQhvnkAj9M8Eu58gMbW9LwEfiF7fDRuzjyYs"
+}

--- a/test/bdd/generate_config.sh
+++ b/test/bdd/generate_config.sh
@@ -8,8 +8,5 @@
 ../../.build/bin/cli create-config --sidetree-url https://localhost:48326/sidetree/0.0.1 \
 --tls-cacerts ../../test/bdd/fixtures/keys/tls/ec-cacert.pem --sidetree-write-token rw_token \
 --recoverykey-file fixtures/keys/recover/public.pem --updatekey-file fixtures/keys/update/public.pem \
---config-file ./fixtures/wellknown/config.json --output-directory ./fixtures/wellknown/jws
-rm -rf ./fixtures/wellknown/jws/stakeholder.one
-rm -rf ./fixtures/wellknown/jws/stakeholder.two
-mv ./fixtures/wellknown/jws/stakeholder.one:8088 ./fixtures/wellknown/jws/stakeholder.one
-mv ./fixtures/wellknown/jws/stakeholder.two:8089 ./fixtures/wellknown/jws/stakeholder.two
+--config-file $1 --output-directory ./fixtures/wellknown/jws
+sleep 1

--- a/test/bdd/generate_stub_config.sh
+++ b/test/bdd/generate_stub_config.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+rm -rf ./fixtures/wellknown/jws/
+
+mkdir -p ./fixtures/wellknown/jws/
+mkdir -p ./fixtures/wellknown/jws/did-trustbloc/
+ > ./fixtures/wellknown/jws/did-trustbloc/testnet.trustbloc.local.json
+ > ./fixtures/wellknown/jws/did-trustbloc/stakeholder.one:8088.json
+ > ./fixtures/wellknown/jws/did-trustbloc/stakeholder.two:8089.json
+
+# directories that cli will write to
+mkdir -p ./fixtures/wellknown/jws/stakeholder.one:8088/
+mkdir -p ./fixtures/wellknown/jws/stakeholder.two:8089/
+ > ./fixtures/wellknown/jws/stakeholder.one:8088/did-configuration.json
+ > ./fixtures/wellknown/jws/stakeholder.two:8089/did-configuration.json
+
+# source directories for docker container bind mounts
+ln -s $PWD/fixtures/wellknown/jws/stakeholder.one:8088 ./fixtures/wellknown/jws/stakeholder.one
+ln -s $PWD/fixtures/wellknown/jws/stakeholder.two:8089 ./fixtures/wellknown/jws/stakeholder.two

--- a/test/bdd/update_config.sh
+++ b/test/bdd/update_config.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+../../.build/bin/cli update-config \
+--config-file $1 --output-directory ./fixtures/wellknown/jws \
+--prev-consortium ./fixtures/wellknown/jws/did-trustbloc/testnet.trustbloc.local.json


### PR DESCRIPTION
Adds bdd tests to demonstrate consortium config update, with one test for successful verification of an updated config, and one test showing failed verification of an updated config.

PR also adds support for genesis files and consortium config updating to did-method-rest.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>