### PR TITLE
chore: update sidetree-core (add reveal value), sidetree-mock

### DIFF
--- a/cmd/did-method-cli/deactivatedidcmd/deactivatedid_test.go
+++ b/cmd/did-method-cli/deactivatedidcmd/deactivatedid_test.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package deactivatedidcmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func TestMissingArg(t *testing.T) {
 
 func TestDeactivateDID(t *testing.T) {
 	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "{}")
 	}))
 	defer serv.Close()
 

--- a/cmd/did-method-cli/go.mod
+++ b/cmd/did-method-cli/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693
 	github.com/stretchr/testify v1.6.1
 	github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc
-	github.com/trustbloc/sidetree-core-go v0.1.5
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f
 	github.com/trustbloc/trustbloc-did-method v0.0.0
 )
 

--- a/cmd/did-method-cli/go.sum
+++ b/cmd/did-method-cli/go.sum
@@ -796,8 +796,8 @@ github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygee
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc h1:sGjZhZKuOB/x4ZUXkrID05RwVYvHDg5fe5BQhhubE0g=
 github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
-github.com/trustbloc/sidetree-core-go v0.1.5 h1:a4DLyNRHRYfbsLC5Q5SWHP1QBGdaG2UDq9ACspqfa38=
-github.com/trustbloc/sidetree-core-go v0.1.5/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f h1:PHySA3TTpo8xChoP3XlTlrs2wHjkoX6K8A3mbdjVvrs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/cmd/did-method-rest/go.sum
+++ b/cmd/did-method-rest/go.sum
@@ -801,8 +801,8 @@ github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc h1:sGjZhZKuO
 github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e h1:i+hGa8C1MKGO71j3jIV7e2aKX72/DTrzLjq9R8kc6xk=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
-github.com/trustbloc/sidetree-core-go v0.1.5 h1:a4DLyNRHRYfbsLC5Q5SWHP1QBGdaG2UDq9ACspqfa38=
-github.com/trustbloc/sidetree-core-go v0.1.5/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f h1:PHySA3TTpo8xChoP3XlTlrs2wHjkoX6K8A3mbdjVvrs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/go.mod
+++ b/go.mod
@@ -18,5 +18,5 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693
 	github.com/stretchr/testify v1.6.1
-	github.com/trustbloc/sidetree-core-go v0.1.5
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f
 )

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygee
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e h1:i+hGa8C1MKGO71j3jIV7e2aKX72/DTrzLjq9R8kc6xk=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
-github.com/trustbloc/sidetree-core-go v0.1.5 h1:a4DLyNRHRYfbsLC5Q5SWHP1QBGdaG2UDq9ACspqfa38=
-github.com/trustbloc/sidetree-core-go v0.1.5/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f h1:PHySA3TTpo8xChoP3XlTlrs2wHjkoX6K8A3mbdjVvrs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=

--- a/pkg/did/option/deactivate/option.go
+++ b/pkg/did/option/deactivate/option.go
@@ -16,6 +16,7 @@ type Opts struct {
 	SidetreeEndpoints []*models.Endpoint
 	SigningKey        crypto.PrivateKey
 	SigningKeyID      string
+	RevealValue       string
 }
 
 // Option is a deactivate DID option
@@ -40,5 +41,12 @@ func WithSigningKey(signingKey crypto.PrivateKey) Option {
 func WithSigningKeyID(id string) Option {
 	return func(opts *Opts) {
 		opts.SigningKeyID = id
+	}
+}
+
+// WithRevealValue sets reveal value
+func WithRevealValue(rv string) Option {
+	return func(opts *Opts) {
+		opts.RevealValue = rv
 	}
 }

--- a/pkg/did/option/recovery/option.go
+++ b/pkg/did/option/recovery/option.go
@@ -23,6 +23,7 @@ type Opts struct {
 	NextUpdatePublicKey   crypto.PublicKey
 	SigningKey            crypto.PrivateKey
 	SigningKeyID          string
+	RevealValue           string
 }
 
 // Option is a recover DID option
@@ -75,5 +76,12 @@ func WithSigningKey(signingKey crypto.PrivateKey) Option {
 func WithSigningKeyID(id string) Option {
 	return func(opts *Opts) {
 		opts.SigningKeyID = id
+	}
+}
+
+// WithRevealValue sets reveal value
+func WithRevealValue(rv string) Option {
+	return func(opts *Opts) {
+		opts.RevealValue = rv
 	}
 }

--- a/pkg/did/option/update/option.go
+++ b/pkg/did/option/update/option.go
@@ -27,6 +27,7 @@ type Opts struct {
 	NextUpdatePublicKey crypto.PublicKey
 	SigningKey          crypto.PrivateKey
 	SigningKeyID        string
+	RevealValue         string
 }
 
 // WithAddPublicKey set public key to be added
@@ -83,5 +84,12 @@ func WithSidetreeEndpoint(sidetreeEndpoint string) Option {
 	return func(opts *Opts) {
 		opts.SidetreeEndpoints = append(opts.SidetreeEndpoints,
 			&models.Endpoint{URL: sidetreeEndpoint})
+	}
+}
+
+// WithRevealValue sets reveal value
+func WithRevealValue(rv string) Option {
+	return func(opts *Opts) {
+		opts.RevealValue = rv
 	}
 }

--- a/test/bdd/fixtures/sidetree-mock/.env
+++ b/test/bdd/fixtures/sidetree-mock/.env
@@ -4,6 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-
-SIDETREE_MOCK_IMAGE=docker.pkg.github.com/trustbloc/sidetree-mock/sidetree-mock
-SIDETREE_MOCK_IMAGE_TAG=0.1.5
+SIDETREE_MOCK_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/sidetree-mock
+SIDETREE_MOCK_IMAGE_TAG=0.1.6-snapshot-7947e73

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -853,8 +853,8 @@ github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygee
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc h1:sGjZhZKuOB/x4ZUXkrID05RwVYvHDg5fe5BQhhubE0g=
 github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
-github.com/trustbloc/sidetree-core-go v0.1.5 h1:a4DLyNRHRYfbsLC5Q5SWHP1QBGdaG2UDq9ACspqfa38=
-github.com/trustbloc/sidetree-core-go v0.1.5/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f h1:PHySA3TTpo8xChoP3XlTlrs2wHjkoX6K8A3mbdjVvrs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=


### PR DESCRIPTION
Update sidetree-core, sidetree-mock:
- add reveal value to update, recover, deactivate

Created #246 to address management of reveal value (already planned in 1.6)

Closes #245

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>